### PR TITLE
Added code coverage target to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,27 @@
 cmake_minimum_required(VERSION 2.6)
 find_package(Rock)
 set(ROCK_USE_CXX11 TRUE)
+set(ROCK_TEST_ENABLED ON)
+
+if(COVERAGE)
+    if(CMAKE_BUILD_TYPE MATCHES Debug)
+        add_definitions(-fprofile-arcs -ftest-coverage)
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage -lgcov")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fprofile-arcs -ftest-coverage -lgcov")
+        set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage -lgcov")
+        
+        add_custom_target(coverage
+          COMMAND lcov --directory . --capture --output-file cov.info
+          COMMAND lcov --remove cov.info 'tests/*' '/usr/*' '*/install/include/*' --output-file cov.info.cleaned
+          COMMAND genhtml -o ./cov cov.info.cleaned
+          COMMAND cmake -E remove cov.info cov.info.cleaned
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        )
+    else()
+        message(FATAL_ERROR "Code coverage only works in Debug versions" )
+    endif()
+endif()
+
 rock_init(envire_maps 0.1)
 rock_standard_layout()
 

--- a/src/Grid.hpp
+++ b/src/Grid.hpp
@@ -173,14 +173,6 @@ namespace envire
 							default_value);  	
 			}		
 
-			bool hasData() 
-			{
-				if (holder->num_elements() == 0)
-					return false;
-				else
-					return true;
-			}
-
 			ArrayType& getArray()
 			{
 				if (holder->num_elements() == 0)


### PR DESCRIPTION
This is the same code that is also used in envire_core to create a code coverage report.
Coverage reports are always nice :)
