### PR TITLE
added missing include to TraversibilityMap3d.hpp

### DIFF
--- a/src/grid/TraversabilityMap3d.cpp
+++ b/src/grid/TraversabilityMap3d.cpp
@@ -25,6 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 #include "TraversabilityMap3d.hpp"
+#include <unordered_set>
 
 namespace maps { namespace grid
 {


### PR DESCRIPTION
To fix this error:

```
TraversabilityMap3d.cpp:88:16: error: ‘visited’ was not declared in this scope
                 if(visited.find(neighbor) != visited.end())
```