### PR TITLE
SimpleTraversability added.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,8 @@ rock_library(maps
         tools/TSDFPolygonMeshReconstruction.cpp
         tools/TSDF_MLSMapReconstruction.cpp
         tools/MLSToSlopes.cpp
+        tools/SimpleTraversability.cpp
+        tools/SimpleTraversabilityRadialLUT.cpp
     HEADERS
         LocalMap.hpp
         grid/Index.hpp
@@ -57,6 +59,8 @@ rock_library(maps
         tools/MarchingCubes.hpp
         tools/SurfaceIntersection.hpp
         tools/MLSToSlopes.hpp
+        tools/SimpleTraversability.hpp
+        tools/SimpleTraversabilityRadialLUT.hpp
         operations/GridInterpolation.hpp
     DEPS_PKGCONFIG 
         base-types 

--- a/src/tools/SimpleTraversability.cpp
+++ b/src/tools/SimpleTraversability.cpp
@@ -1,0 +1,249 @@
+//
+// Copyright (c) 2015-2017, Deutsches Forschungszentrum für Künstliche Intelligenz GmbH.
+// Copyright (c) 2015-2017, University of Bremen
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#include "SimpleTraversability.hpp"
+#include "SimpleTraversabilityRadialLUT.hpp"
+
+using namespace maps;
+using namespace tools;
+
+SimpleTraversability::SimpleTraversability()
+{
+}
+
+SimpleTraversability::SimpleTraversability(
+        const SimpleTraversabilityConfig& config)
+    : config(config)
+{
+}
+
+SimpleTraversability::SimpleTraversability(
+        double maximumSlope,
+        unsigned int classCount,
+        double groundClearance,
+        double minPassageWidth,
+        double obstacleClearance)
+{
+    config.maximumSlope      = maximumSlope;
+    config.classCount        = classCount;
+    config.groundClearance   = groundClearance;
+    config.minPassageWidth   = minPassageWidth;
+    config.obstacleClearance = obstacleClearance;
+}
+
+void SimpleTraversability::setConfig(const SimpleTraversabilityConfig& config)
+{
+    this->config = config;
+}
+
+void SimpleTraversability::setConfig(double maximumSlope, unsigned int classCount, double groundClearance, double minPassageWidth, double obstacleClearance)
+{
+    config.maximumSlope = maximumSlope;
+    config.classCount = classCount;
+    config.groundClearance = groundClearance;
+    config.minPassageWidth = minPassageWidth;
+    config.obstacleClearance = obstacleClearance;
+}
+
+const SimpleTraversabilityConfig& SimpleTraversability::getConfig() const
+{
+    return config;
+}
+
+
+bool SimpleTraversability::calculateTraversability(grid::TraversabilityGrid& traversabilityOut, const grid::GridMapF& slopesIn, const grid::GridMapF& maxStepsIn) const
+{
+    // Check for equal input map sizes and resolutions.
+    if (maxStepsIn.getNumCells() != slopesIn.getNumCells() || maxStepsIn.getResolution() != slopesIn.getResolution())
+        return false;
+
+    // Init TraversabilityGrid with traversabilityClassId = 0 and probability = 0.
+    traversabilityOut = grid::TraversabilityGrid(slopesIn.getNumCells(), slopesIn.getResolution(), grid::TraversabilityCell(0, 0));
+
+    int width = traversabilityOut.getNumCells()[0], height = traversabilityOut.getNumCells()[1];
+    for (int y = 0; y < height; ++y)
+    {
+        for (int x = 0; x < width; ++x)
+        {
+            // Read the values for this cell.
+            bool hasSlope     = false,
+                 hasMaxStep   = false;
+
+            float slope = slopesIn.at(grid::Index(x, y));
+            if (!slopesIn.isDefault(slope))
+                hasSlope = true;
+
+            float maxStep =  maxStepsIn.at(grid::Index(x, y));
+            if (!maxStepsIn.isDefault(maxStep))
+                hasMaxStep = true;
+
+            // First, max_step is an ON/OFF threshold on the groundClearance parameter.
+            if (hasMaxStep && config.groundClearance && (fabs(maxStep) > config.groundClearance))
+            {
+                traversabilityOut.setTraversabilityAndProbability(CLASS_OBSTACLE, 1, x, y);
+                continue;
+            }
+
+            if (!hasSlope)
+            {
+                traversabilityOut.setTraversability(CLASS_UNKNOWN, x, y);
+                continue;
+            }
+
+            if (hasSlope && config.maximumSlope)
+            {
+                const float absSlope(fabs(slope));
+                if(absSlope > config.maximumSlope)
+                {
+                    traversabilityOut.setTraversabilityAndProbability(CLASS_OBSTACLE, 1, x, y);
+                    continue;
+                }
+                else
+                {
+                    // Scale current slope to custom classes (antiproportional).
+                    int customClassIdx = (config.classCount - 1) - rint(absSlope / config.maximumSlope * (config.classCount - 1));
+                    traversabilityOut.setTraversabilityAndProbability(CUSTOM_CLASSES + customClassIdx, 1, x, y);
+                }
+            }
+        }
+    }
+
+    // Perform some post processing if required.
+    if (config.minPassageWidth > 0)
+    {
+        closeNarrowPassages(traversabilityOut, config.minPassageWidth);
+    }
+
+    if (config.obstacleClearance > 0)
+    {
+        growObstacles(traversabilityOut, config.obstacleClearance);
+    }
+
+    // Registers TraversabilityClasses in the TraversabilityGrid.
+    traversabilityOut.setTraversabilityClass(CLASS_OBSTACLE, grid::TraversabilityClass(0));
+
+    float driveability = 0.0;
+    for (int i = 0; i < config.classCount; ++i)
+    {
+        driveability = (1.0 / config.classCount) * (i + 1);
+        traversabilityOut.setTraversabilityClass(CUSTOM_CLASSES + i, grid::TraversabilityClass(driveability));
+    }
+
+    // Calculates the mean traversability class of the current map ignoring unknown areas.
+    uint8_t classId = 0;
+    double summedClassIds = 0.0;
+    double counter = 0.0;
+    for (int y = 0; y < height; ++y)
+    {
+        for (int x = 0; x < width; ++x)
+        {
+            classId = traversabilityOut.getTraversabilityClassId(x, y);
+
+            // Sum up if not unknown.
+            if(classId != CLASS_UNKNOWN) {
+                summedClassIds += classId;
+                counter++;
+            }
+        }
+    }
+
+    double medianDriveability = 0.55;
+    uint8_t meanClassId = counter == 0 ? 0 : summedClassIds / counter + 0.5;
+
+    // If the map is completely unkown or full with obstacles,
+    // set the driveability of unknown areas to the median driveability (0.55).
+    if(meanClassId <= 1) {
+        traversabilityOut.setTraversabilityClass(CLASS_UNKNOWN, grid::TraversabilityClass(medianDriveability));
+    } else {
+        grid::TraversabilityClass meanTravClass = traversabilityOut.getTraversabilityClass(meanClassId);
+        traversabilityOut.setTraversabilityClass(CLASS_UNKNOWN, meanTravClass);
+    }
+
+    return true;
+}
+
+void SimpleTraversability::closeNarrowPassages(grid::TraversabilityGrid& traversabilityGrid, double minPassageWidth) const
+{
+    SimpleTraversabilityRadialLUT lut;
+    lut.precompute(minPassageWidth, traversabilityGrid.getResolution()[0], traversabilityGrid.getResolution()[1]);
+
+    size_t mapWidth = traversabilityGrid.getNumCells()[0];
+    size_t mapHeight = traversabilityGrid.getNumCells()[1];
+
+    grid::TraversabilityGrid traversabilityGridTmp = traversabilityGrid;
+
+    for (size_t y = 0; y < mapHeight; ++y)
+    {
+        for (size_t x = 0; x < mapWidth; ++x)
+        {
+            int traversabilityClassId = traversabilityGridTmp.at(grid::Index(x, y)).getTraversabilityClassId();
+            if (traversabilityClassId == CLASS_OBSTACLE)
+            {
+                lut.markAllRadius(traversabilityGrid, x, y, CLASS_OBSTACLE);
+            }
+        }
+    }
+}
+
+void SimpleTraversability::growObstacles(grid::TraversabilityGrid& traversabilityGrid, double growthRadius) const
+{
+    const double growthRadius_squared = pow(growthRadius,2);
+
+    const double resolutionX = traversabilityGrid.getResolution()[0],
+                 resolutionY = traversabilityGrid.getResolution()[1];
+
+    const int growthRadius_cellCountX = growthRadius / resolutionX,
+              growthRadius_cellCountY = growthRadius / resolutionY;
+
+    grid::TraversabilityGrid traversabilityGridTmp = traversabilityGrid;
+
+    for (unsigned int y = 0; y < traversabilityGrid.getNumCells()[1]; ++y)
+    {
+        for (unsigned int x = 0; x < traversabilityGrid.getNumCells()[0]; ++x)
+        {
+            int classId = traversabilityGridTmp.at(grid::Index(x, y)).getTraversabilityClassId();
+            if (classId == CLASS_OBSTACLE)
+            {
+                // Make everything within obstacleClearance range around the obstacle also
+                // an obstacle.
+                for (int oy = -growthRadius_cellCountY; oy <= growthRadius_cellCountY; ++oy)
+                {
+                    for (int ox = -growthRadius_cellCountX; ox <= growthRadius_cellCountX; ++ox)
+                    {
+                        const int tx = x + ox;
+                        const int ty = y + oy;
+                        if ((pow(ox * resolutionX, 2) + pow(oy * resolutionY, 2) < growthRadius_squared)
+                            && tx >= 0 && tx < static_cast<int>(traversabilityGridTmp.getNumCells()[0])
+                            && ty >= 0 && ty < static_cast<int>(traversabilityGridTmp.getNumCells()[1]))
+                        {
+                            traversabilityGrid.setTraversabilityAndProbability(CLASS_OBSTACLE, 1, tx, ty);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/tools/SimpleTraversability.hpp
+++ b/src/tools/SimpleTraversability.hpp
@@ -1,0 +1,182 @@
+//
+// Copyright (c) 2015-2017, Deutsches Forschungszentrum für Künstliche Intelligenz GmbH.
+// Copyright (c) 2015-2017, University of Bremen
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#ifndef __MAPS_SIMPLE_TRAVERSABILITY_HPP_
+#define __MAPS_SIMPLE_TRAVERSABILITY_HPP_
+
+#include <maps/grid/GridMap.hpp>
+#include <maps/grid/TraversabilityGrid.hpp>
+
+namespace maps { namespace tools
+{
+    /** @brief Configuration parameters for the SimpleTraversability operator
+     *
+     * See SimpleTraversability for more information on the use of these
+     * parameters.
+     */
+    struct SimpleTraversabilityConfig
+    {
+        /** The maximum slope the robot is able to traverse */
+        double maximumSlope;
+
+        /** Number of classes in the output map */
+        int classCount;
+
+        /**
+        * Required ground clearance, in meters. A cell is classified as an
+        * obstacle if the maximum step around that cell is higher than the
+        * ground clearance
+        */
+        double groundClearance;
+
+        /**
+        * Traversable passages that are narrower (in m) than this will be
+        * closed
+        */
+        double minPassageWidth;
+
+        /**
+        * Clearance (in m) around obstacles. When set to a value larger than
+        * 0, all obstacles will be grown by a border of given width.
+        */
+        double obstacleClearance;
+
+        SimpleTraversabilityConfig()
+            : maximumSlope(0)
+            , classCount(0)
+            , groundClearance(0)
+            , minPassageWidth(0)
+            , obstacleClearance(0)
+        {
+        }
+
+        SimpleTraversabilityConfig(
+                double maximumSlope,
+                int classCount,
+                double groundClearance,
+                double minPassageWidth = 0,
+                double obstacleClearance = 0)
+
+            : maximumSlope(maximumSlope)
+            , classCount(classCount)
+            , groundClearance(groundClearance)
+            , minPassageWidth(minPassageWidth)
+            , obstacleClearance(obstacleClearance)
+        {
+        }
+
+    };
+
+    /**
+     * @brief Classification of terrain into symbolic traversability classes, based on
+     * geometric constraints
+     *
+     * For now, the modalities that are used are:
+     *
+     * <ul>
+     * <li>maximum slope
+     * <li>maximum step size
+     * </ul>
+     *
+     * The (very simple) model maps the local slope from [@a maximumSlope, 1] to [0, 1].
+     * The resulting value is then quantified in @a classCount intervals.
+     * Probability will be set to 1 for every classification beside CLASS_UNKNOWN.
+     *
+     * It outputs a TraversabilityGrid in which each cell has an integer value,
+     * this integer value being the traversability class for the cell. Since
+     * CLASS_UNKNOWN (=0) and CLASS_OBSTACLE (=1) are reserved, the resulting
+     * traversability class is in [2, 2 + classCount - 1]
+     *
+     * If one of the modalities is missing, it is simply ignored
+     */
+    class SimpleTraversability {
+
+    private:
+
+        SimpleTraversabilityConfig config;
+
+    public:
+
+        enum CLASSES {
+            CLASS_UNKNOWN = 0,
+            CLASS_OBSTACLE = 1,
+            CUSTOM_CLASSES = 2
+        };
+
+        SimpleTraversability();
+
+        SimpleTraversability(
+                const SimpleTraversabilityConfig& config);
+
+        SimpleTraversability(
+                double maximumSlope,
+                unsigned int classCount,
+                double groundClearance,
+                double minPassageWidth = 0,
+                double obstacleClearance = 0);
+
+        void setConfig(const SimpleTraversabilityConfig& config);
+        void setConfig(
+                double maximumSlope,
+                unsigned int classCount,
+                double groundClearance,
+                double minPassageWidth = 0,
+                double obstacleClearance = 0);
+
+        const SimpleTraversabilityConfig& getConfig() const;
+
+        /**
+         * Calculates the traversability based on the input maps.
+         * @details:
+         * Note that the default value of the input maps will be
+         * used to determine UNKNOWN cells.
+         */
+        bool calculateTraversability(grid::TraversabilityGrid& traversabilityOut,
+                                     const grid::GridMapF& slopesIn,
+                                     const grid::GridMapF& maxStepsIn) const;
+
+        /**
+         * Closes spaces between obstacles <= @a minPassageWidth.
+         * Will be called by @ calculateTraversability
+         * (before growObstacles) if
+         * minPassageWidth is greater than 0.
+         */
+        void closeNarrowPassages(maps::grid::TraversabilityGrid& traversabilityGrid, double minPassageWidth) const;
+
+        /**
+         * Grows obstacles by growthRadius.
+         * Will be called by calculateTraversability
+         * (after closeNarrowPassages) if
+         * obstacleClearance is greater than 0.
+         */
+        void growObstacles(maps::grid::TraversabilityGrid& traversabilityGrid, double growthRadius) const;
+
+    };
+
+}  // End namespace tools
+}  // End namespace maps
+
+#endif  //__MAPS_SIMPLE_TRAVERSABILITY_HPP_

--- a/src/tools/SimpleTraversabilityRadialLUT.cpp
+++ b/src/tools/SimpleTraversabilityRadialLUT.cpp
@@ -1,0 +1,129 @@
+//
+// Copyright (c) 2015-2017, Deutsches Forschungszentrum für Künstliche Intelligenz GmbH.
+// Copyright (c) 2015-2017, University of Bremen
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "SimpleTraversabilityRadialLUT.hpp"
+
+#include <boost/tuple/tuple.hpp>
+
+using namespace maps;
+using namespace tools;
+
+void SimpleTraversabilityRadialLUT::precompute(double distance, double resolutionX, double resolutionY)
+{
+    const double radius2 = distance * distance;
+
+    width  = 2 * ceil(distance / resolutionX) + 1;
+    height = 2 * ceil(distance / resolutionY) + 1;
+
+    inDistance.resize(boost::extents[width][height]);
+    std::fill(inDistance.data(), inDistance.data() + inDistance.num_elements(), false);
+
+    parents.resize(boost::extents[width][height]);
+    std::fill(parents.data(), parents.data() + parents.num_elements(), std::make_pair(-1, -1));
+
+    centerX = width  / 2;
+    centerY = height / 2;
+
+    parents[centerX][centerY] = std::make_pair(-1, -1);
+
+    for (unsigned int y = 0; y < height; ++y)
+    {
+        for (unsigned int x = 0; x < width; ++x)
+        {
+            int dx = (x - centerX);
+            int dy = (y - centerY);
+
+            if (dx == 0 && dy == 0)
+                continue;
+
+            double d2 = dx * dx * resolutionX * resolutionX + dy * dy * resolutionY * resolutionY;
+            inDistance[x][y] = (d2 < radius2);
+
+            if (abs(dx) > abs(dy))
+            {
+                int parentx = x - dx / abs(dx);
+                int parenty = y - rint(static_cast<double>(dy) / abs(dx));
+                parents[x][y] = std::make_pair(parentx, parenty);
+            }
+            else
+            {
+                int parentx = x - rint(static_cast<double>(dx) / abs(dy));
+                int parenty = y - dy / abs(dy);
+                parents[x][y] = std::make_pair(parentx, parenty);
+            }
+        }
+    }
+}
+
+void SimpleTraversabilityRadialLUT::markAllRadius(grid::TraversabilityGrid& traversabilityGrid, int centerX, int centerY, int targetedValue) const
+{
+    int baseX = centerX - this->centerX;
+    int baseY = centerY - this->centerY;
+
+    for (unsigned int y = 0; y < height; ++y)
+    {
+        int mapY = baseY + y;
+        if (mapY < 0 || mapY >= static_cast<int>(traversabilityGrid.getNumCells()[1]))
+            continue;
+
+        for (unsigned int x = 0; x < width; ++x)
+        {
+            int mapX = baseX + x;
+            if (mapX < 0 || mapX >= static_cast<int>(traversabilityGrid.getNumCells()[0]))
+                continue;
+
+            if (inDistance[x][y] && traversabilityGrid.at(grid::Index(mapX, mapY)).getTraversabilityClassId() == targetedValue)
+            {
+                markSingleRadius(traversabilityGrid, centerX, centerY, x, y, targetedValue, targetedValue);
+            }
+        }
+    }
+}
+
+void SimpleTraversabilityRadialLUT::markSingleRadius(grid::TraversabilityGrid& traversabilityGrid, int centerX, int centerY, int targetX, int targetY, int expectedValue, int markValue) const
+{
+    boost::tie(targetX, targetY) = parents[targetX][targetY];
+
+    while (targetX != -1 && targetY != -1)
+    {
+        int mapX = centerX + targetX - this->centerX;
+        int mapY = centerY + targetY - this->centerY;
+
+        if (mapX < 0 || mapX >= static_cast<int>(traversabilityGrid.getNumCells()[0]) || mapY < 0 || mapY >= static_cast<int>(traversabilityGrid.getNumCells()[1]))
+        {
+            boost::tie(targetX, targetY) = parents[targetX][targetY];
+            continue;
+        }
+
+        if (traversabilityGrid.at(grid::Index(mapX, mapY)).getTraversabilityClassId() != expectedValue)
+        {
+            traversabilityGrid.setTraversabilityAndProbability(markValue, 1, mapX, mapY);
+        }
+
+        boost::tie(targetX, targetY) = parents[targetX][targetY];
+    }
+}

--- a/src/tools/SimpleTraversabilityRadialLUT.hpp
+++ b/src/tools/SimpleTraversabilityRadialLUT.hpp
@@ -1,0 +1,70 @@
+//
+// Copyright (c) 2015-2017, Deutsches Forschungszentrum für Künstliche Intelligenz GmbH.
+// Copyright (c) 2015-2017, University of Bremen
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#ifndef __MAPS_SIMPLE_TRAVERSABILITY_RADIAL_LUT_HPP_
+#define __MAPS_SIMPLE_TRAVERSABILITY_RADIAL_LUT_HPP_
+
+#include "maps/grid/TraversabilityGrid.hpp"
+#include "boost/multi_array.hpp"
+
+namespace maps { namespace tools
+{
+
+    /**
+     * Radial lookup table used in SimpleTraversability::closeNarrowPassages.
+    **/
+    class SimpleTraversabilityRadialLUT
+    {
+    private:
+        int centerX, centerY;
+        unsigned int width, height;
+        boost::multi_array<std::pair<int, int>, 2>  parents;
+        boost::multi_array<bool, 2> inDistance;
+
+    public:
+        /**
+        * Sets up parents and inDistance so they cover a grid of
+        * (@a distance * 2) x (@a distance * 2) with an additional
+        * Cell as the center.
+        */
+        void precompute(double distance, double resolutionX, double resolutionY);
+
+        /**
+        * Checks for the targetedValue within the in distance around the given center and calls markSingleRadius on them.
+        */
+        void markAllRadius(grid::TraversabilityGrid& traversabilityGrid, int centerX, int centerY, int targetedValue) const;
+
+        /**
+         * Marks all cells between target and center with the @a markValue using the @a parents table.
+         */
+        void markSingleRadius(grid::TraversabilityGrid& traversabilityGrid, int centerX, int centerY, int targetX, int targetY, int expectedValue, int markValue) const;
+
+    };
+
+}  // End namespace tools.
+}  // End namespace maps.
+
+#endif  // __MAPS_SIMPLE_TRAVERSABILITY_RADIAL_LUT_HPP_

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -15,3 +15,7 @@ rock_testsuite(test_surface_intersection
 rock_testsuite(test_MLSToSlopes
    test_tools_MLSToSlopes.cpp
    DEPS maps)
+
+rock_testsuite(test_SimpleTraversability
+   test_tools_SimpleTraversability.cpp
+   DEPS maps)

--- a/test/tools/test_tools_SimpleTraversability.cpp
+++ b/test/tools/test_tools_SimpleTraversability.cpp
@@ -1,0 +1,446 @@
+//
+// Copyright (c) 2015-2017, Deutsches Forschungszentrum für Künstliche Intelligenz GmbH.
+// Copyright (c) 2015-2017, University of Bremen
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#define BOOST_TEST_MODULE ToolsTest
+#include <boost/test/unit_test.hpp>
+
+#include "maps/grid/TraversabilityGrid.hpp"
+#include "maps/grid/GridMap.hpp"
+#include "maps/tools/SimpleTraversability.hpp"
+#include "maps/grid/Index.hpp"
+#include "typeinfo"
+
+using namespace maps;
+using namespace grid;
+using namespace tools;
+
+#include <boost/core/demangle.hpp>
+
+struct Fixture
+{
+    Fixture()
+    {
+    }
+
+    ~Fixture()
+    {
+    }
+
+    const double maximumSlope = 0.5,
+                minPassageWidth = 0.4829381,
+                groundClearance = 3,
+                obstacleClearance = 0.53123124;
+
+    const int classCount = 20;
+
+    const Vector2ui numCells = Vector2ui(50, 60);
+    const Vector2d resolution = Vector2d(0.12354498, 0.241387654);
+
+    SimpleTraversabilityConfig config =  SimpleTraversabilityConfig(maximumSlope, classCount, groundClearance, minPassageWidth, obstacleClearance);
+    SimpleTraversabilityConfig confNoPP = SimpleTraversabilityConfig(maximumSlope, classCount, groundClearance);
+
+    TraversabilityGrid traversabilityGrid = TraversabilityGrid();
+    SimpleTraversability simpleTraversability = SimpleTraversability(config);
+
+    GridMapF slopesIn = GridMapF(numCells, resolution, -std::numeric_limits<double>::infinity()),
+             maxStepsIn = GridMapF(numCells, resolution, -std::numeric_limits<double>::infinity());
+
+    void addSinuses(GridMapF& map, double amplitude, double wavelength, int direction)
+    {
+        for (unsigned int y = 0; y < numCells[1]; ++y)
+        {
+            for (unsigned int x = 0; x < numCells[0]; ++x)
+            {
+                if (map.at(x, y) == -std::numeric_limits<double>::infinity())
+                    map.at(x, y) = 0;
+                if (direction == 0)
+                    map.at(x, y) += std::sin(x / (wavelength * 2)) * amplitude;
+                if (direction == 1)
+                    map.at(x, y) += std::sin(y / (wavelength * 2)) * amplitude;
+            }
+        }
+    }
+};
+
+// CONSTRUCTORS
+BOOST_AUTO_TEST_CASE(test_simpleTraversabilityConfig_defaultConstructor)
+{
+    SimpleTraversabilityConfig config = SimpleTraversabilityConfig();
+
+    BOOST_CHECK_EQUAL(config.maximumSlope, 0);
+    BOOST_CHECK_EQUAL(config.classCount, 0);
+    BOOST_CHECK_EQUAL(config.groundClearance, 0);
+    BOOST_CHECK_EQUAL(config.minPassageWidth, 0);
+    BOOST_CHECK_EQUAL(config.obstacleClearance, 0);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_simpleTraversabilityConfig_parameterizedConstructor, Fixture)
+{
+    BOOST_CHECK_EQUAL(config.maximumSlope, maximumSlope);
+    BOOST_CHECK_EQUAL(config.classCount, classCount);
+    BOOST_CHECK_EQUAL(config.groundClearance, groundClearance);
+    BOOST_CHECK_EQUAL(config.minPassageWidth, minPassageWidth);
+    BOOST_CHECK_EQUAL(config.obstacleClearance, obstacleClearance);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_simpleTraversabilityConfig_parameterizedConstructor_noPostProcessing, Fixture)
+{
+    BOOST_CHECK_EQUAL(confNoPP.maximumSlope, maximumSlope);
+    BOOST_CHECK_EQUAL(confNoPP.classCount, classCount);
+    BOOST_CHECK_EQUAL(confNoPP.groundClearance, groundClearance);
+    BOOST_CHECK_EQUAL(confNoPP.minPassageWidth, 0);
+    BOOST_CHECK_EQUAL(confNoPP.obstacleClearance, 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_simpleTraversability_defaultConstructor)
+{
+    SimpleTraversability simpleTraversability = SimpleTraversability();
+    SimpleTraversabilityConfig confOut = simpleTraversability.getConfig();
+
+    BOOST_CHECK_EQUAL(confOut.maximumSlope, 0);
+    BOOST_CHECK_EQUAL(confOut.classCount, 0);
+    BOOST_CHECK_EQUAL(confOut.groundClearance, 0);
+    BOOST_CHECK_EQUAL(confOut.minPassageWidth, 0);
+    BOOST_CHECK_EQUAL(confOut.obstacleClearance, 0);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_simpleTraversability_constructor_passedConfig, Fixture)
+{
+    SimpleTraversabilityConfig confOut = simpleTraversability.getConfig();
+
+    BOOST_CHECK_EQUAL(confOut.maximumSlope, maximumSlope);
+    BOOST_CHECK_EQUAL(confOut.classCount, classCount);
+    BOOST_CHECK_EQUAL(confOut.groundClearance, groundClearance);
+    BOOST_CHECK_EQUAL(confOut.minPassageWidth, minPassageWidth);
+    BOOST_CHECK_EQUAL(confOut.obstacleClearance, obstacleClearance);
+}
+
+BOOST_AUTO_TEST_CASE(test_simpleTraversability_constructor_passedParamerters)
+{
+    SimpleTraversability simpleTraversability = SimpleTraversability(0, 1, 2, 3, 4);
+
+    SimpleTraversabilityConfig confOut = simpleTraversability.getConfig();
+    BOOST_CHECK_EQUAL(confOut.maximumSlope, 0);
+    BOOST_CHECK_EQUAL(confOut.classCount, 1);
+    BOOST_CHECK_EQUAL(confOut.groundClearance, 2);
+    BOOST_CHECK_EQUAL(confOut.minPassageWidth, 3);
+    BOOST_CHECK_EQUAL(confOut.obstacleClearance, 4);
+}
+
+BOOST_AUTO_TEST_CASE(test_simpleTraversability_constructor_passedParamerters_noPostProcessing)
+{
+    SimpleTraversability simpleTraversability = SimpleTraversability(0, 1, 2);
+
+    SimpleTraversabilityConfig confOut = simpleTraversability.getConfig();
+    BOOST_CHECK_EQUAL(confOut.maximumSlope, 0);
+    BOOST_CHECK_EQUAL(confOut.classCount, 1);
+    BOOST_CHECK_EQUAL(confOut.groundClearance, 2);
+    BOOST_CHECK_EQUAL(confOut.minPassageWidth, 0);
+    BOOST_CHECK_EQUAL(confOut.obstacleClearance, 0);
+}
+
+// SETTERS AND GETTERS
+BOOST_FIXTURE_TEST_CASE(test_simpleTraversability_settersAndGetters, Fixture)
+{
+    SimpleTraversabilityConfig config = simpleTraversability.getConfig();
+    BOOST_CHECK_EQUAL(config.maximumSlope, maximumSlope);
+    BOOST_CHECK_EQUAL(config.classCount, classCount);
+    BOOST_CHECK_EQUAL(config.groundClearance, groundClearance);
+    BOOST_CHECK_EQUAL(config.minPassageWidth, minPassageWidth);
+    BOOST_CHECK_EQUAL(config.obstacleClearance, obstacleClearance);
+
+    simpleTraversability.setConfig(0.1, 5, 0.2, 0.3, 0.4);
+
+    config = simpleTraversability.getConfig();
+    BOOST_CHECK_EQUAL(config.maximumSlope, 0.1);
+    BOOST_CHECK_EQUAL(config.classCount, 5);
+    BOOST_CHECK_EQUAL(config.groundClearance, 0.2);
+    BOOST_CHECK_EQUAL(config.minPassageWidth, 0.3);
+    BOOST_CHECK_EQUAL(config.obstacleClearance, 0.4);
+
+    SimpleTraversabilityConfig newConf = SimpleTraversabilityConfig(1.1, 10, 1.2, 1.3, 1.4);
+    simpleTraversability.setConfig(newConf);
+
+    config = simpleTraversability.getConfig();
+    BOOST_CHECK_EQUAL(config.maximumSlope, 1.1);
+    BOOST_CHECK_EQUAL(config.classCount, 10);
+    BOOST_CHECK_EQUAL(config.groundClearance, 1.2);
+    BOOST_CHECK_EQUAL(config.minPassageWidth, 1.3);
+    BOOST_CHECK_EQUAL(config.obstacleClearance, 1.4);
+
+}
+
+// CALCULATE_TRAVERSABILITY
+BOOST_FIXTURE_TEST_CASE(test_simpleTraversability_emptyMap, Fixture)
+{
+    simpleTraversability.calculateTraversability(traversabilityGrid, slopesIn, maxStepsIn);
+
+    for (unsigned int y = 0; y < numCells[1]; ++y)
+    {
+        for (unsigned int x = 0; x < numCells[0]; ++x)
+        {
+            BOOST_CHECK_EQUAL(traversabilityGrid.getTraversabilityClassId(x, y), 0);
+            BOOST_CHECK_CLOSE(traversabilityGrid.getTraversability(x, y).getDrivability(), 0.55, 0.1);
+        }
+    }
+
+    BOOST_CHECK_CLOSE(traversabilityGrid.getTraversabilityClass(0).getDrivability(), 0.55, 0.1);
+    BOOST_CHECK_EQUAL(traversabilityGrid.getTraversabilityClass(1).getDrivability(), 0);
+    BOOST_CHECK_CLOSE(traversabilityGrid.getTraversabilityClass(SimpleTraversability::CUSTOM_CLASSES + classCount - 1).getDrivability(), 1, 0.1);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_simpleTraversability_obstacleFilled, Fixture)
+{
+    for (unsigned int y = 0; y < numCells[1]; ++y)
+    {
+        for (unsigned int x = 0; x < numCells[0]; ++x)
+        {
+            slopesIn.at(x, y) = 100;
+        }
+    }
+
+    simpleTraversability.calculateTraversability(traversabilityGrid, slopesIn, maxStepsIn);
+
+    for (unsigned int y = 0; y < numCells[1]; ++y)
+    {
+        for (unsigned int x = 0; x < numCells[0]; ++x)
+        {
+            BOOST_CHECK_EQUAL(traversabilityGrid.getTraversabilityClassId(x, y), 1);
+            BOOST_CHECK_EQUAL(traversabilityGrid.getTraversability(x, y).getDrivability(), 0);
+        }
+    }
+
+    BOOST_CHECK_CLOSE(traversabilityGrid.getTraversabilityClass(0).getDrivability(), 0.55, 0.1);
+    BOOST_CHECK_EQUAL(traversabilityGrid.getTraversabilityClass(1).getDrivability(), 0);
+    BOOST_CHECK_CLOSE(traversabilityGrid.getTraversabilityClass(SimpleTraversability::CUSTOM_CLASSES + classCount - 1).getDrivability(), 1, 0.1);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_simpleTraversability_slopeSinuses_horizontalAndVertical_noPostProcessing, Fixture)
+{
+    addSinuses(slopesIn, maximumSlope * 1.5, 50 * (resolution[0] / 1.5), 0);
+    addSinuses(slopesIn, maximumSlope * 1.5, 50 * (resolution[1] / 1.5), 1);
+
+    simpleTraversability.setConfig(confNoPP);
+    simpleTraversability.calculateTraversability(traversabilityGrid, slopesIn, maxStepsIn);
+
+    for (unsigned int i = 0; i - 2 < traversabilityGrid.getTraversabilityClasses().size(); ++i)
+    {
+        BOOST_CHECK_CLOSE(traversabilityGrid.getTraversabilityClass(i + 2).getDrivability(), 1.0 / classCount * (i + 1), 0.1);
+    }
+
+    int counter = 0;
+    double idSum = 0;
+
+    for (unsigned int y = 0; y < numCells[1]; ++y)
+    {
+        for (unsigned int x = 0; x < numCells[0]; ++x)
+        {
+            if (traversabilityGrid.getTraversabilityClassId(x, y) != 0)
+            {
+                ++counter;
+                idSum += traversabilityGrid.getTraversabilityClassId(x, y);
+            }
+
+            if (fabs(slopesIn.at(x, y)) > maximumSlope)
+            {
+                BOOST_CHECK_EQUAL(traversabilityGrid.getTraversabilityClassId(x, y), 1);
+            }
+            else
+            {
+                BOOST_CHECK_EQUAL(traversabilityGrid.getTraversabilityClassId(x, y), (classCount - 1) - rint(fabs(slopesIn.at(x, y)) / maximumSlope * (classCount - 1)) + 2);
+            }
+        }
+    }
+
+    int medianId = rint(idSum / counter);
+    if (medianId > 1)
+        BOOST_CHECK_CLOSE(traversabilityGrid.getTraversabilityClass(0).getDrivability(), traversabilityGrid.getTraversabilityClass(medianId).getDrivability(), 0.1);
+    else
+        BOOST_CHECK_CLOSE(traversabilityGrid.getTraversabilityClass(0).getDrivability(), 0.55, 0.1);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_simpleTraversability_maxStepSinuses_horizontalAndVertical_noPostProcessing, Fixture)
+{
+    addSinuses(maxStepsIn, groundClearance * 1.5, 50 * (resolution[0] / 1.5), 0);
+    addSinuses(maxStepsIn, groundClearance * 1.5, 50 * (resolution[1] / 1.5), 1);
+
+    simpleTraversability.setConfig(confNoPP);
+    simpleTraversability.calculateTraversability(traversabilityGrid, slopesIn, maxStepsIn);
+
+    for (unsigned int i = 0; i - 2 < traversabilityGrid.getTraversabilityClasses().size(); ++i)
+    {
+        BOOST_CHECK_CLOSE(traversabilityGrid.getTraversabilityClass(i + 2).getDrivability(), 1.0 / classCount * (i + 1), 0.1);
+    }
+
+    int counter = 0;
+    double idSum = 0;
+
+    for (unsigned int y = 0; y < numCells[1]; ++y)
+    {
+        for (unsigned int x = 0; x < numCells[0]; ++x)
+        {
+            if (traversabilityGrid.getTraversabilityClassId(x, y) != 0)
+            {
+                ++counter;
+                idSum += traversabilityGrid.getTraversabilityClassId(x, y);
+            }
+
+            if (fabs(maxStepsIn.at(x, y)) > groundClearance)
+            {
+                BOOST_CHECK_EQUAL(traversabilityGrid.getTraversabilityClassId(x, y), 1);
+            }
+            else
+            {
+                BOOST_CHECK_EQUAL(traversabilityGrid.getTraversabilityClassId(x, y), 0);
+            }
+        }
+    }
+
+    int medianId = rint(idSum / counter);
+    if (medianId > 1)
+        BOOST_CHECK_CLOSE(traversabilityGrid.getTraversabilityClass(0).getDrivability(), traversabilityGrid.getTraversabilityClass(medianId).getDrivability(), 0.1);
+    else
+        BOOST_CHECK_CLOSE(traversabilityGrid.getTraversabilityClass(0).getDrivability(), 0.55, 0.1);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_simpleTraversability_maxStepAndSlopeSinuses_horizontalAndVertical_noPostProcessing, Fixture)
+{
+    addSinuses(maxStepsIn, groundClearance * 1.5, 50 * (resolution[0] / 1.5), 0);
+    addSinuses(maxStepsIn, groundClearance * 1.5, 50 * (resolution[1] / 1.5), 1);
+    addSinuses(slopesIn, maximumSlope * 1.5, 50 * (resolution[0] / 1.5), 0);
+    addSinuses(slopesIn, maximumSlope * 1.5, 50 * (resolution[1] / 1.5), 1);
+
+    simpleTraversability.setConfig(confNoPP);
+    simpleTraversability.calculateTraversability(traversabilityGrid, slopesIn, maxStepsIn);
+
+    for (unsigned int i = 0; i - 2 < traversabilityGrid.getTraversabilityClasses().size(); ++i)
+    {
+        BOOST_CHECK_CLOSE(traversabilityGrid.getTraversabilityClass(i + 2).getDrivability(), 1.0 / classCount * (i + 1), 0.1);
+    }
+
+    int counter = 0;
+    double idSum = 0;
+
+    for (unsigned int y = 0; y < numCells[1]; ++y)
+    {
+        for (unsigned int x = 0; x < numCells[0]; ++x)
+        {
+            if (traversabilityGrid.getTraversabilityClassId(x, y) != 0)
+            {
+                ++counter;
+                idSum += traversabilityGrid.getTraversabilityClassId(x, y);
+            }
+
+            if (fabs(maxStepsIn.at(x, y)) > groundClearance)
+            {
+                BOOST_CHECK_EQUAL(traversabilityGrid.getTraversabilityClassId(x, y), 1);
+                continue;
+            }
+
+            if (fabs(slopesIn.at(x, y)) > maximumSlope)
+            {
+                BOOST_CHECK_EQUAL(traversabilityGrid.getTraversabilityClassId(x, y), 1);
+            }
+            else if (!slopesIn.isDefault(slopesIn.at(x, y)))
+            {
+                BOOST_CHECK_EQUAL(traversabilityGrid.getTraversabilityClassId(x, y), (classCount - 1) - rint(fabs(slopesIn.at(x, y)) / maximumSlope * (classCount - 1)) + 2);
+            }
+            else
+            {
+                BOOST_CHECK_EQUAL(traversabilityGrid.getTraversabilityClassId(x, y), 0);
+                continue;
+            }
+        }
+    }
+
+    int medianId = rint(idSum / counter);
+    if (medianId > 1)
+        BOOST_CHECK_CLOSE(traversabilityGrid.getTraversabilityClass(0).getDrivability(), traversabilityGrid.getTraversabilityClass(medianId).getDrivability(), 0.1);
+    else
+        BOOST_CHECK_CLOSE(traversabilityGrid.getTraversabilityClass(0).getDrivability(), 0.55, 0.1);
+}
+
+
+// POSTPROCESSING
+BOOST_FIXTURE_TEST_CASE(test_simpleTraversability_closeNarrowPassage, Fixture)
+{
+    unsigned int xPosition = numCells[0] / 2;
+    unsigned int yPosition1 = numCells[1] / 3;
+    unsigned int yPosition2 = minPassageWidth / resolution[1] + yPosition1;
+
+    for (int x = -2; x <= 2; ++x)
+    {
+        unsigned int mapX = xPosition + x;
+        if (mapX < 0 || yPosition1 < 0 || yPosition2 < 0 || mapX >= numCells[0] || yPosition1 >= numCells[1] || yPosition2 >= numCells[1])
+            continue;
+        maxStepsIn.at(xPosition + x, yPosition1) = groundClearance + 1;
+        maxStepsIn.at(xPosition + x, yPosition2) = groundClearance + 1;
+    }
+
+    simpleTraversability.setConfig(config);
+
+    simpleTraversability.calculateTraversability(traversabilityGrid, slopesIn, maxStepsIn);
+
+    for (unsigned int y = yPosition1; y <= yPosition2; ++y)
+    {
+        for (unsigned int x = xPosition - 2; x <= xPosition + 2; ++x)
+        {
+            BOOST_CHECK_EQUAL(traversabilityGrid.getTraversabilityClassId(xPosition, y), 1);
+        }
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(test_simpleTraversability_growObstacles, Fixture)
+{
+    int xPosition = numCells[0] / 2;
+    int yPosition = numCells[1] / 2;
+
+    maxStepsIn.at(xPosition, yPosition) = groundClearance + 1;
+
+    simpleTraversability.setConfig(config);
+    simpleTraversability.calculateTraversability(traversabilityGrid, slopesIn, maxStepsIn);
+
+    int growthWidthX = obstacleClearance / resolution[0];
+    int growthWidthY = obstacleClearance / resolution[1];
+
+    for (int y = -growthWidthY; y <= growthWidthY; ++y)
+    {
+        for (int x = -growthWidthX; x <= growthWidthX; ++x)
+        {
+            unsigned int mapX = xPosition + x;
+            unsigned int mapY = yPosition + y;
+            if (mapX < 0 || mapY < 0 || mapX >= numCells[0] || mapY >= numCells[1])
+                continue;
+
+            double squaredDistance = pow(x * resolution[0], 2) + pow(y * resolution[1], 2);
+
+            if (squaredDistance < pow(obstacleClearance, 2))
+                BOOST_CHECK_EQUAL(traversabilityGrid.getTraversabilityClassId(mapX, mapY), 1);
+            else
+                BOOST_CHECK_EQUAL(traversabilityGrid.getTraversabilityClassId(mapX, mapY), 0);
+        }
+    }
+}


### PR DESCRIPTION
In addition to the main class the helper class
SimpleTraversabilityRadialLUT was added, which
is used in the postprocessing methods of
SimpleTraversability:

In addition Unit Tests were added for
SimpleTraversability and the neccessary changes
were made to the CMakeLists.

Changes in comparison to the envire version:
Constructors and Configs
- Setters and Getters for the SimpleTraversabilityConfig were added
  as well as a new constructor for the Config making the use of
  Configs more convenient.
- Postprocessing parameters now have a default value of 0 in all
  constructors.
- ObstacleClearance was addded to the config and the constructors
  enabling the use of growObstacles.

calculateTraversability
- Will now check if the value of an input differs from the
  input maps default value to determine UNKNOWN areas.

RadialLUT and closeNarrowPassages
- RadialLUT was moved to its own file and renamed
  SimpleTraversabilityRadialLUT.
- closeNarrowPassages will now use a copy of the map instead of
  using 255 as a marking value. These changes are also apparent
  in RadialLUT which does the marking.
- closeNarrowPassages will now use the whole RadialLUT instead
  of only one quadrant. A check was added to prevent access to
  cells outside of the grid.