### PR TITLE
GridmapVisualisation Update.

### DIFF
--- a/test/viz/test_viz_GridMap.cpp
+++ b/test/viz/test_viz_GridMap.cpp
@@ -58,6 +58,47 @@ static void showGridMap(const GridMap<CellT> &grid_map)
     }
 }
 
+BOOST_AUTO_TEST_CASE(gridviz_test_min)
+{
+    Vector2ui numCells(4, 4);
+    Vector2d resolution(0.05, 0.05);
+
+    GridMap<double> grid_map(numCells, resolution, -0.01);
+
+    for (unsigned int y = 0; y < grid_map.getNumCells().y(); ++y)
+    {
+        for (unsigned int x = 0; x < grid_map.getNumCells().x(); ++x)
+        {
+            if (x == 0 || y == 0 || x == numCells.x() - 1 || y  == numCells.y() - 1)
+                grid_map.at(x, y) = -0.01;
+            else
+                grid_map.at(x, y) = 0.001 * (x + y) - 0.01;
+        }
+    }
+
+    showGridMap(grid_map);
+}
+
+BOOST_AUTO_TEST_CASE(gridviz_test_min_full)
+{
+    Vector2ui numCells(8, 10);
+    Vector2d resolution(0.01, 0.02);
+
+    GridMap<double> grid_map(numCells, resolution, -0.01);
+
+    grid_map.getLocalFrame().translation() << 0.5 * grid_map.getSize(), 0;
+
+    for (unsigned int y = 0; y < grid_map.getNumCells().y(); ++y)
+    {
+        for (unsigned int x = 0; x < grid_map.getNumCells().x(); ++x)
+        {
+                grid_map.at(x, y) = 0.001 * (x + y) - 0.01;
+        }
+    }
+
+    showGridMap(grid_map);
+}
+
 BOOST_AUTO_TEST_CASE(gridviz_test)
 {
     GridMap<double> grid_map(Vector2ui(150, 250), Vector2d(0.1, 0.1), -10.);

--- a/viz/GridMapVisualization.hpp
+++ b/viz/GridMapVisualization.hpp
@@ -49,6 +49,9 @@ namespace vizkit3d
         Q_OBJECT
 
         Q_PROPERTY(bool showMapExtents READ areMapExtentsShown WRITE setShowMapExtents)
+        Q_PROPERTY(bool showHeightField READ isHeightFieldShown WRITE setShowHeightField)
+        Q_PROPERTY(bool interpolateCellColors READ areCellColorsInterpolated WRITE setInterpolateCellColors)
+        Q_PROPERTY(bool useNPOTTextures READ areNPOTTexturesUsed WRITE setUseNPOTTextures)
 
         public:
             GridMapVisualization();
@@ -77,8 +80,19 @@ namespace vizkit3d
 
             osg::ref_ptr<osg::Geode> geode;
 
+            bool showHeightField;
+            bool interpolateCellColors;
+            bool useNPOTTextures;
 
         public slots:
+            void setShowHeightField(bool enabled);
+            bool isHeightFieldShown() const;
+
+            void setInterpolateCellColors(bool enabled);
+            bool areCellColorsInterpolated() const;
+
+            void setUseNPOTTextures(bool enabled);
+            bool areNPOTTexturesUsed() const;
     };
 }
 #endif


### PR DESCRIPTION
Fixes a minor bug with the heightfield.
(The Heightfield is actually drawn from cell center to
cell center so for an accurate visualization of the data
it has to be translated by half a cell on the x and y axes
and the applied texture has to be rescaled.)

Added a Q_PROPERTY to en-/disable the use of NPOT textures.

Added a Q_PROPERTY to en-/disable the heightmap.
If disabled a plane is created instead.

Adds a Q_PROPERTY to en-/disable interpolation
of colors between cells.