### PR TITLE
add optional "connected surface" mode for mls visualization

### DIFF
--- a/test/grid/test_GridMap.cpp
+++ b/test/grid/test_GridMap.cpp
@@ -32,6 +32,7 @@
 #include <boost/math/special_functions/fpclassify.hpp>
 
 #include <chrono>
+#include <iostream>
 
 using namespace ::maps::grid;
 

--- a/test/grid/test_MLGrid.cpp
+++ b/test/grid/test_MLGrid.cpp
@@ -34,6 +34,8 @@
 #include <maps/grid/GridFacade.hpp>
 #include <maps/grid/LevelList.hpp>
 
+#include <iostream>
+
 using namespace ::maps::grid;
 class PatchBase
 {

--- a/viz/CMakeLists.txt
+++ b/viz/CMakeLists.txt
@@ -4,6 +4,7 @@ if (vizkit3d_FOUND AND OSGVIZ_PRIMITIVES_FOUND)
     rock_vizkit_plugin(maps-viz
             PluginLoader.cpp
             PatchesGeode.cpp
+            SurfaceGeode.cpp
             StandaloneVisualizer.cpp
         MOC
             GridMapVisualization.cpp
@@ -22,6 +23,7 @@ if (vizkit3d_FOUND AND OSGVIZ_PRIMITIVES_FOUND)
             MLSMapVisualization.hpp
             TraversabilityMap3dVisualization.hpp
             PatchesGeode.hpp
+            SurfaceGeode.hpp
             StandaloneVisualizer.hpp
             ContourMapVisualization.hpp
             OccupancyGridMapVisualization.hpp

--- a/viz/MLSMapVisualization.cpp
+++ b/viz/MLSMapVisualization.cpp
@@ -316,31 +316,28 @@ void MLSMapVisualization::updateMainNode ( osg::Node* node )
     geode->setShowNormals(showNormals);
     geode->setUncertaintyScale(uncertaintyScale);
 
-    if (connectedSurface) {
-        p->visualize(*geode, 1);
-    } else {
+    if (!connectedSurface) {
         p->visualize(*geode, 0);
+    } else {
+        p->visualize(*geode, 1);
+
+        osg::ref_ptr<SurfaceGeode> sgeode = new SurfaceGeode(res.x(), res.y());
+        localNode->addChild( sgeode );
+        if(cycleHeightColor)
+        {
+            sgeode->showCycleColor(true);
+            sgeode->setCycleColorInterval(cycleColorInterval);
+            sgeode->setColorHSVA(0, 1.0, 0.6, 1.0);
+        } else {
+            sgeode->setColor(horizontalCellColor);
+        }
+        sgeode->setShowPatchExtents(showPatchExtents);
+        sgeode->setShowNormals(showNormals);
+        sgeode->setUncertaintyScale(uncertaintyScale);
+
+        p->visualize(*sgeode);
+
     }
-    
-
-
-    osg::ref_ptr<SurfaceGeode> sgeode = new SurfaceGeode(res.x(), res.y());
-    localNode->addChild( sgeode );
-    if(cycleHeightColor)
-    {
-        sgeode->showCycleColor(true);
-        sgeode->setCycleColorInterval(cycleColorInterval);
-        sgeode->setColorHSVA(0, 1.0, 0.6, 1.0);
-    }
-    else
-        sgeode->setColor(horizontalCellColor);
-    sgeode->setShowPatchExtents(showPatchExtents);
-    sgeode->setShowNormals(showNormals);
-    sgeode->setUncertaintyScale(uncertaintyScale);
-
-    p->visualize(*sgeode);
-
-
 
     if( showUncertainty || showNormals || showPatchExtents)
     {

--- a/viz/MLSMapVisualization.hpp
+++ b/viz/MLSMapVisualization.hpp
@@ -60,6 +60,7 @@ namespace vizkit3d
         Q_PROPERTY(QColor vertical_cell_color READ getVerticalCellColor WRITE setVerticalCellColor)
         Q_PROPERTY(QColor negative_cell_color READ getNegativeCellColor WRITE setNegativeCellColor)
         Q_PROPERTY(QColor uncertainty_color READ getUncertaintyColor WRITE setUncertaintyColor)
+        Q_PROPERTY(bool connected_surface READ isConnectedSurface WRITE setConnectedSurface)
 
         public:
             MLSMapVisualization();
@@ -143,6 +144,9 @@ namespace vizkit3d
             double getUncertaintyScale() const;
             void setUncertaintyScale(double scaling);
 
+            bool isConnectedSurface() const;
+            void setConnectedSurface(bool enabled);
+
         protected:
             osg::Vec4 horizontalCellColor;
             osg::Vec4 verticalCellColor;
@@ -157,6 +161,7 @@ namespace vizkit3d
             double cycleColorInterval;
             bool showPatchExtents;
             double uncertaintyScale;
+            bool connectedSurface;
 
 #if 0
             osg::Vec3 estimateNormal(

--- a/viz/MLSMapVisualization.hpp
+++ b/viz/MLSMapVisualization.hpp
@@ -50,17 +50,17 @@ namespace vizkit3d
         Q_PROPERTY(bool show_map_extents READ areMapExtentsShown WRITE setShowMapExtents)
         Q_PROPERTY(bool show_uncertainty READ isUncertaintyShown WRITE setShowUncertainty)
         Q_PROPERTY(bool show_negative READ isNegativeShown WRITE setShowNegative)
-        Q_PROPERTY(bool show_patch_extents READ arePatchExtentsShown WRITE setShowPatchExtents)        
+        Q_PROPERTY(bool show_patch_extents READ arePatchExtentsShown WRITE setShowPatchExtents)
         Q_PROPERTY(bool estimate_normals READ areNormalsEstimated WRITE setEstimateNormals)
         Q_PROPERTY(bool show_normals READ areNormalsShown WRITE setShowNormals)
         Q_PROPERTY(bool cycle_height_color READ isHeightColorCycled WRITE setCycleHeightColor)
         Q_PROPERTY(double cycle_color_interval READ getCycleColorInterval WRITE setCycleColorInterval)
         Q_PROPERTY(double uncertainty_scale READ getUncertaintyScale WRITE setUncertaintyScale)
+        Q_PROPERTY(bool connected_surface READ isConnectedSurface WRITE setConnectedSurface)
         Q_PROPERTY(QColor horizontal_cell_color READ getHorizontalCellColor WRITE setHorizontalCellColor)
         Q_PROPERTY(QColor vertical_cell_color READ getVerticalCellColor WRITE setVerticalCellColor)
         Q_PROPERTY(QColor negative_cell_color READ getNegativeCellColor WRITE setNegativeCellColor)
         Q_PROPERTY(QColor uncertainty_color READ getUncertaintyColor WRITE setUncertaintyColor)
-        Q_PROPERTY(bool connected_surface READ isConnectedSurface WRITE setConnectedSurface)
 
         public:
             MLSMapVisualization();

--- a/viz/SurfaceGeode.cpp
+++ b/viz/SurfaceGeode.cpp
@@ -1,0 +1,134 @@
+//
+// Copyright (c) 2015-2017, Deutsches Forschungszentrum für Künstliche Intelligenz GmbH.
+// Copyright (c) 2015-2017, University of Bremen
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#include "SurfaceGeode.hpp"
+
+#include <vizkit3d/ColorConversionHelper.hpp>
+
+#include <maps/tools/SurfaceIntersection.hpp>
+
+namespace vizkit3d
+{
+    SurfaceGeode::SurfaceGeode(float x_res, float y_res)
+        : vertex_index(0),
+          xp(0), yp(0),
+          xs(x_res), ys(y_res),
+          hue(0.0),
+          sat(1.0),
+          alpha(1.0),
+          lum(1.0),
+          cycle_color(false),
+          uncertaintyScale(1.0)
+    {
+        colors = new osg::Vec4Array;
+        vertices = new osg::Vec3Array;
+        normals = new osg::Vec3Array;
+        geom = new osg::Geometry;
+        var_vertices = new osg::Vec3Array;
+
+        showNormals = true;
+        showPatchExtents = false;
+
+        geom->setUseVertexBufferObjects(true);
+
+        geom->setVertexArray(vertices);
+        geom->setNormalArray(normals);
+        geom->setNormalBinding(osg::Geometry::BIND_PER_VERTEX);
+        geom->setColorArray(colors);
+        geom->setColorBinding(osg::Geometry::BIND_PER_VERTEX);
+
+        addDrawable(geom);
+    }
+
+    void SurfaceGeode::addVertex(const osg::Vec3& p, const osg::Vec3& n, const float & stdev)
+    {
+        vertices->push_back( p );
+        normals->push_back( n );
+
+        if( cycle_color )
+        {
+            hue = (p.z() - std::floor(p.z() / cycle_color_interval) * cycle_color_interval) / cycle_color_interval;
+            alpha = std::max( 0.0, (uncertaintyScale - stdev) / uncertaintyScale);
+            updateColor();
+        }
+
+        colors->push_back( color );
+
+    }
+
+
+    void SurfaceGeode::updateColor()
+    {
+        vizkit3d::hslToRgb(hue, sat, lum , color.x(), color.y(), color.z());
+        color.w() = alpha;
+    }
+
+    void SurfaceGeode::setColor(const osg::Vec4& color)
+    {
+        // TODO ideally this should also change the HSVA values
+        this->color = color;
+    }
+
+    void SurfaceGeode::setColorHSVA(float hue, float sat, float lum, float alpha)
+    {
+        this->hue = hue;
+        this->sat = sat;
+        this->alpha = alpha;
+        this->lum = lum;
+
+        updateColor();
+    }
+
+    void SurfaceGeode::setCycleColorInterval(float cycle_color_interval)
+    {
+        this->cycle_color_interval = cycle_color_interval;
+    }
+
+    void SurfaceGeode::showCycleColor(bool cycle_color)
+    {
+        this->cycle_color = cycle_color;
+    }
+
+    void SurfaceGeode::setUncertaintyScale(double uncertainty_scale)
+    {
+        this->uncertaintyScale = uncertainty_scale;
+    }
+
+    void SurfaceGeode::drawLines()
+    {
+        osg::ref_ptr<osg::Geometry> var_geom = new osg::Geometry;
+        var_geom->setVertexArray( var_vertices );
+        osg::ref_ptr<osg::DrawArrays> drawArrays = new osg::DrawArrays( osg::PrimitiveSet::LINES, 0, var_vertices->size() );
+        var_geom->addPrimitiveSet(drawArrays.get());
+
+        osg::ref_ptr<osg::Vec4Array> var_color = new osg::Vec4Array;
+        var_color->push_back( osg::Vec4( 0.5, 0.1, 0.8, 1.0 ) );
+        var_geom->setColorArray( var_color.get() );
+        var_geom->setColorBinding( osg::Geometry::BIND_OVERALL );
+
+        addDrawable( var_geom.get() );
+    }
+} // namespace vizkit3d

--- a/viz/SurfaceGeode.hpp
+++ b/viz/SurfaceGeode.hpp
@@ -1,0 +1,97 @@
+//
+// Copyright (c) 2015-2017, Deutsches Forschungszentrum für Künstliche Intelligenz GmbH.
+// Copyright (c) 2015-2017, University of Bremen
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#ifndef __VIZKIT_SURFACEGEODE_HPP__
+#define __VIZKIT_SURFACEGEODE_HPP__
+
+#include <osg/Geometry>
+#include <osg/Geode>
+#include <Eigen/Geometry>
+#include <Eigen/StdVector>
+
+#include <base-logging/Logging.hpp>
+
+namespace vizkit3d {
+
+    class SurfaceGeode : public osg::Geode
+    {
+    public:
+        SurfaceGeode(float x_res, float y_res);
+
+        void setColor(const osg::Vec4& color);
+        void setColorHSVA(float hue, float sat, float lum, float alpha);
+
+        void showCycleColor(bool cycle_color);
+        void setCycleColorInterval(float cycle_color_interval);
+        void setUncertaintyScale(double uncertainty_scale);
+
+        void setShowPatchExtents(bool enable = true) { showPatchExtents = enable; };
+        void setShowNormals(bool enable = true) { showNormals = enable; };
+        void setShowUncertainty(bool enable = true) { showUncertainty = enable; }
+        void drawLines();
+
+
+        void addVertex(const osg::Vec3& p, const osg::Vec3& n, const float & stdev = 0.f);
+
+        void closeTriangleStrip(){
+            geom->addPrimitiveSet(new osg::DrawArrays(osg::PrimitiveSet::TRIANGLE_STRIP,vertex_index,vertices->size()-vertex_index));
+            vertex_index = vertices->size();
+        }
+
+    private:
+        osg::ref_ptr<osg::Vec3Array> vertices;
+        osg::ref_ptr<osg::Vec3Array> normals;
+        osg::ref_ptr<osg::Vec4Array> colors;  
+        osg::ref_ptr<osg::Geometry> geom;  
+
+        osg::ref_ptr<osg::Vec3Array> var_vertices;
+
+        size_t vertex_index;
+
+        float xp, yp; // position of current patch
+        float xs, ys; // grid resolution
+
+        float hue;
+        float sat; 
+        float alpha; 
+        float lum;
+        osg::Vec4 color; 
+
+        bool showNormals;
+        bool showPatchExtents;
+        bool showUncertainty;
+        bool cycle_color;
+        float cycle_color_interval;
+        double uncertaintyScale;
+
+        
+        void updateColor();
+
+    };
+
+}
+
+#endif // __VIZKIT_PATCHESGEODE_HPP__


### PR DESCRIPTION
This adds a "connected_surface" mode (default off) for MLS Visualization, analogue to:

https://github.com/rock-slam/slam-envire/pull/2

It uses all lowest grid entries and draws them as a mesh instead of boxes, expecting that the lowest values id the ground.