### PR TITLE
Compatibility for Ubuntu 20.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 # CMakeLists.txt has to be located in the project folder and cmake has to be
 # executed from 'project/build' with 'cmake ../'.
 cmake_minimum_required(VERSION 2.6)
-set(ROCK_USE_CXX11 TRUE)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(Rock)
 
 if(COVERAGE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 # CMakeLists.txt has to be located in the project folder and cmake has to be
 # executed from 'project/build' with 'cmake ../'.
 cmake_minimum_required(VERSION 2.6)
+project(maps VERSION 0.1)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(Rock)
@@ -30,5 +31,5 @@ endif()
 
 add_definitions(-DNUMERIC_DEPRECATE=1 )
 
-rock_init(maps 0.1)
+rock_init()
 rock_standard_layout()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeLists.txt has to be located in the project folder and cmake has to be
 # executed from 'project/build' with 'cmake ../'.
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.0)
 project(maps VERSION 0.1)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -32,4 +32,6 @@ endif()
 add_definitions(-DNUMERIC_DEPRECATE=1 )
 
 rock_init()
+rock_find_qt4()
 rock_standard_layout()
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,5 +78,4 @@ rock_library(maps
         Boost_SYSTEM 
         Boost_FILESYSTEM 
         Boost_SERIALIZATION
-        CGAL
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,11 +71,12 @@ rock_library(maps
     DEPS_PKGCONFIG 
         base-types 
         base-logging
-        pcl_common-${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}
-        pcl_io-${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}
         boost_serialization
     DEPS_PLAIN
         Boost_SYSTEM 
         Boost_FILESYSTEM 
         Boost_SERIALIZATION
+        PCL_COMMON
+        PCL_IO
 )
+

--- a/src/grid/TraversabilityCell.hpp
+++ b/src/grid/TraversabilityCell.hpp
@@ -31,6 +31,7 @@
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/export.hpp>
+#include <stdint.h>
 
 namespace maps { namespace grid
 {

--- a/viz/CMakeLists.txt
+++ b/viz/CMakeLists.txt
@@ -1,4 +1,9 @@
 pkg_check_modules(OSGVIZ_PRIMITIVES PrimitivesFactory)
+pkg_check_modules(OSG REQUIRED openscenegraph)
+
+if(${OSG_VERSION} VERSION_GREATER_EQUAL 3.6.4)
+    add_compile_definitions(NEW_OSG)
+endif()
 
 if (vizkit3d_FOUND AND OSGVIZ_PRIMITIVES_FOUND)
     rock_vizkit_plugin(maps-viz

--- a/viz/MLSMapVisualization.cpp
+++ b/viz/MLSMapVisualization.cpp
@@ -174,7 +174,7 @@ void visualize(vizkit3d::SurfaceGeode& geode) const
             }
             //compute normals
             osgUtil::SmoothingVisitor smoothingVisitor;
-            smoothingVisitor.apply(geode);
+            smoothingVisitor.apply(*geode.getGeometry());
             geode.setDataVariance(osg::Object::STATIC);
         }
 

--- a/viz/MLSMapVisualization.cpp
+++ b/viz/MLSMapVisualization.cpp
@@ -174,7 +174,11 @@ void visualize(vizkit3d::SurfaceGeode& geode) const
             }
             //compute normals
             osgUtil::SmoothingVisitor smoothingVisitor;
+#ifdef NEW_OSG
             smoothingVisitor.apply(*geode.getGeometry());
+#else
+            smoothingVisitor.apply(geode);
+#endif
             geode.setDataVariance(osg::Object::STATIC);
         }
 

--- a/viz/SurfaceGeode.hpp
+++ b/viz/SurfaceGeode.hpp
@@ -60,6 +60,9 @@ namespace vizkit3d {
             geom->addPrimitiveSet(new osg::DrawArrays(osg::PrimitiveSet::TRIANGLE_STRIP,vertex_index,vertices->size()-vertex_index));
             vertex_index = vertices->size();
         }
+        inline osg::ref_ptr<osg::Geometry> getGeometry(){
+            return geom;
+        }
 
     private:
         osg::ref_ptr<osg::Vec3Array> vertices;

--- a/viz/SurfaceGeode.hpp
+++ b/viz/SurfaceGeode.hpp
@@ -60,9 +60,11 @@ namespace vizkit3d {
             geom->addPrimitiveSet(new osg::DrawArrays(osg::PrimitiveSet::TRIANGLE_STRIP,vertex_index,vertices->size()-vertex_index));
             vertex_index = vertices->size();
         }
+#ifdef NEW_OSG
         inline osg::ref_ptr<osg::Geometry> getGeometry(){
             return geom;
         }
+#endif
 
     private:
         osg::ref_ptr<osg::Vec3Array> vertices;


### PR DESCRIPTION
1) Missing header led to compile errors such as:

```
In file included from /home/malte/Development/artemis/slam/maps/src/grid/TraversabilityCell.cpp:27:
/home/malte/Development/artemis/slam/maps/src/grid/TraversabilityCell.hpp:45:9: error: ‘uint8_t’ does not name a type; did you mean ‘u_int8_t’?
   45 |         uint8_t traversabilityClassId;
      |         ^~~~~~~
      |         u_int8_t
/home/malte/Development/artemis/slam/maps/src/grid/TraversabilityCell.hpp:46:9: error: ‘uint8_t’ does not name a type; did you mean ‘u_int8_t’?
   46 |         uint8_t probability;

```

2) SmoothingVisitor::apply is defined as
```c++
virtual void apply(osg::Geometry& geom);
```
Thus passing `vizkit3d::SurfaceGeode` (subclass of osg::Geode) led to conversion error in compilation.

3) C++14 is needed for newer versions of pcl

4) CGAL is header only since version 5

**Reviewer:** Please double check 2). I'm not sure if the patch really correct. It compiles, but if in earlier versions of osg it was possible to pass Geode instead of Geometry or the API for SmoothingVisitor was different, semantics might not be correct.