### PR TITLE
Enhanced visualization of MLS-Map

### DIFF
--- a/src/grid/SurfacePatches.hpp
+++ b/src/grid/SurfacePatches.hpp
@@ -268,6 +268,11 @@ public:
         return z_pos;
     }
 
+    int getNumerOfMeasurements() const
+    {
+        return n;
+    }
+
 protected:
     /** Grants access to boost serialization */
     friend class boost::serialization::access;

--- a/src/grid/SurfacePatches.hpp
+++ b/src/grid/SurfacePatches.hpp
@@ -268,7 +268,7 @@ public:
         return z_pos;
     }
 
-    int getNumerOfMeasurements() const
+    int getNumberOfMeasurements() const
     {
         return n;
     }

--- a/viz/MLSMapVisualization.cpp
+++ b/viz/MLSMapVisualization.cpp
@@ -60,50 +60,6 @@ osg::Quat Quat( const Eigen::Quaternion<T, options>& q )
     return osg::Quat( q.x(), q.y(), q.z(), q.w() );
 }
 
-namespace vizkit3d {
-struct PatchVisualizer
-{
-    static void visualize(vizkit3d::PatchesGeode& geode, const SurfacePatch<MLSConfig::SLOPE>& p)
-    {
-        float minZ, maxZ;
-        p.getRange(minZ, maxZ);
-        minZ -= 5e-4f;
-        maxZ += 5e-4f;
-        Eigen::Vector3f normal = p.getNormal();
-        if(normal.allFinite())
-        {
-            geode.drawPlane(Eigen::Hyperplane<float, 3>(p.getNormal(), p.getCenter()), minZ, maxZ);
-        }
-        else
-        {
-            float height = (maxZ - minZ) + 1e-3f;
-            geode.drawBox(maxZ, height, osg::Vec3(0.f,0.f,1.f));
-        }
-    }
-    static void visualize(vizkit3d::PatchesGeode& geode, const SurfacePatch<MLSConfig::PRECALCULATED>& p)
-    {
-        float minZ, maxZ;
-        p.getRange(minZ, maxZ);
-        minZ -= 5e-4f;
-        maxZ += 5e-4f;
-        geode.drawPlane(p.getPlane(), minZ, maxZ, 1e-4f);
-    }
-    static void visualize(vizkit3d::PatchesGeode& geode, const SurfacePatch<MLSConfig::KALMAN>& p)
-    {
-        if(p.isHorizontal())
-            geode.drawHorizontalPlane(p.getMean(), p.getStandardDeviation());
-        else
-            geode.drawBox(p.getMean(), p.getHeight(), Vec3(p.getNormal()));
-    }
-    static void visualize(vizkit3d::PatchesGeode& geode, const SurfacePatch<MLSConfig::BASE>& p)
-    {
-        geode.drawBox(p.getTop(), p.getTop()-p.getBottom(), Vec3(p.getNormal()));
-    }
-
-
-};
-}
-
 struct MLSMapVisualization::Data {
     // Copy of the value given to updateDataIntern.
     //
@@ -115,6 +71,7 @@ struct MLSMapVisualization::Data {
     virtual void visualizeNegativeInformation(vizkit3d::PatchesGeode& geode) const = 0;
     virtual maps::grid::CellExtents getCellExtents() const = 0;
     virtual base::Transform3d getLocalFrame() const = 0;
+    MLSMapVisualization* visualization;
 };
 
 template<enum MLSConfig::update_model Type>
@@ -200,7 +157,7 @@ void visualize(vizkit3d::SurfaceGeode& geode) const
                     if (list.size()){
                         for (typename Cell::const_iterator it = list.begin()+levelOffset; it != list.end(); it++)
                         {
-                            PatchVisualizer::visualize(geode, *it);
+                            visualization->visualize(geode, *it);
                         } // for(SPList ...)
                     }
                 } // for(y ...)
@@ -275,6 +232,7 @@ MLSMapVisualization::MLSMapVisualization()
     cycleColorInterval(1.0),
     showPatchExtents(false),
     uncertaintyScale(1.0),
+    minMeasurements(1),
     connectedSurface(false),
     simplifySurface(true),
     connected_surface_lod(false)
@@ -387,15 +345,18 @@ void MLSMapVisualization::updateDataIntern(::maps::grid::MLSMapKalman const& val
 void MLSMapVisualization::updateDataIntern(::maps::grid::MLSMap<::maps::grid::MLSConfig::SLOPE> const& value)
 {
     p.reset(new DataHold<MLSConfig::SLOPE>( value ));
+    p->visualization = this;
 }
 void MLSMapVisualization::updateDataIntern(::maps::grid::MLSMap<::maps::grid::MLSConfig::PRECALCULATED> const& value)
 {
     p.reset(new DataHold<MLSConfig::PRECALCULATED>( value ));
+    p->visualization = this;
 }
 
 void MLSMapVisualization::updateDataIntern(::maps::grid::MLSMap<::maps::grid::MLSConfig::BASE> const& value)
 {
     p.reset(new DataHold<MLSConfig::BASE>( value ));
+    p->visualization = this;
 }
 
 bool MLSMapVisualization::isUncertaintyShown() const
@@ -617,8 +578,59 @@ void MLSMapVisualization::setSimplifySurface(bool enabled)
     setDirty();
 }
 
+int MLSMapVisualization::getMinMeasurements() const
+{
+    return minMeasurements;
+}
+void MLSMapVisualization::setMinMeasurements(int measurements)
+{
+    minMeasurements = measurements;
+    emit propertyChanged("min_measurements");
+    setDirty();
+}
 
+void MLSMapVisualization::visualize(vizkit3d::PatchesGeode& geode, const SurfacePatch<MLSConfig::SLOPE>& p)
+{
+    float minZ, maxZ;
+    p.getRange(minZ, maxZ);
+    minZ -= 5e-4f;
+    maxZ += 5e-4f;
+    Eigen::Vector3f normal = p.getNormal();
+    if(p.getNumerOfMeasurements() > minMeasurements)
+    {
+        if(normal.allFinite())
+        {
+            geode.drawPlane(Eigen::Hyperplane<float, 3>(p.getNormal(), p.getCenter()), minZ, maxZ);
+        }
+        else
+        {
+            float height = (maxZ - minZ) + 1e-3f;
+            geode.drawBox(maxZ, height, osg::Vec3(0.f,0.f,1.f));
+        }
+    }
+}
 
+void MLSMapVisualization::visualize(vizkit3d::PatchesGeode& geode, const SurfacePatch<MLSConfig::PRECALCULATED>& p)
+{
+    float minZ, maxZ;
+    p.getRange(minZ, maxZ);
+    minZ -= 5e-4f;
+    maxZ += 5e-4f;
+    geode.drawPlane(p.getPlane(), minZ, maxZ, 1e-4f);
+}
+
+void MLSMapVisualization::visualize(vizkit3d::PatchesGeode& geode, const SurfacePatch<MLSConfig::KALMAN>& p)
+{
+    if(p.isHorizontal())
+        geode.drawHorizontalPlane(p.getMean(), p.getStandardDeviation());
+    else
+        geode.drawBox(p.getMean(), p.getHeight(), Vec3(p.getNormal()));
+}
+
+void MLSMapVisualization::visualize(vizkit3d::PatchesGeode& geode, const SurfacePatch<MLSConfig::BASE>& p)
+{
+    geode.drawBox(p.getTop(), p.getTop()-p.getBottom(), Vec3(p.getNormal()));
+}
 
 //Macro that makes this plugin loadable in ruby, this is optional.
 //VizkitQtPlugin(MLSMapVisualization)

--- a/viz/MLSMapVisualization.cpp
+++ b/viz/MLSMapVisualization.cpp
@@ -91,7 +91,6 @@ public:
 void visualize(vizkit3d::SurfaceGeode& geode) const
     {
         Vector2ui num_cell = mls.getNumCells();
-        double lastheight = 0;
 
             for (size_t y = 0; y < num_cell.y()-1; y++) {
                 for (size_t x = 0; x < num_cell.x(); x++) {
@@ -120,9 +119,6 @@ void visualize(vizkit3d::SurfaceGeode& geode) const
                         // adding the neighbor first to make the SmoothingVisitor work properly
                         geode.addVertex( osg::Vec3f(pos.x(),npos.y(),npos.z()), osg::Vec3f(nposnormal.x(),nposnormal.y(),nposnormal.z()) );
                         geode.addVertex( osg::Vec3f(pos.x(),pos.y(),pos.z()), osg::Vec3f(posnormal.x(),posnormal.y(),posnormal.z()) );
-
-                        lastheight = height;
-
 
                     }else{
                         geode.closeTriangleStrip();

--- a/viz/MLSMapVisualization.cpp
+++ b/viz/MLSMapVisualization.cpp
@@ -596,11 +596,13 @@ void MLSMapVisualization::visualize(vizkit3d::PatchesGeode& geode, const Surface
     minZ -= 5e-4f;
     maxZ += 5e-4f;
     Eigen::Vector3f normal = p.getNormal();
-    if(p.getNumerOfMeasurements() > minMeasurements)
+    if(normal.z() < 0)
+        normal *= -1.0;
+    if(p.getNumerOfMeasurements() >= minMeasurements)
     {
         if(normal.allFinite())
         {
-            geode.drawPlane(Eigen::Hyperplane<float, 3>(p.getNormal(), p.getCenter()), minZ, maxZ);
+            geode.drawPlane(Eigen::Hyperplane<float, 3>(normal, p.getCenter()), minZ, maxZ);
         }
         else
         {

--- a/viz/MLSMapVisualization.cpp
+++ b/viz/MLSMapVisualization.cpp
@@ -64,6 +64,7 @@ struct MLSMapVisualization::Data {
     // Copy of the value given to updateDataIntern.
     //
     // Making a copy is required because of how OSG works
+    Data(MLSMapVisualization& vis):visualization(vis) {}
     virtual ~Data() { }
     virtual Eigen::Vector2d getResolution() const = 0;
     virtual void visualize(vizkit3d::PatchesGeode& geode, int levelOffset) const = 0;
@@ -71,7 +72,7 @@ struct MLSMapVisualization::Data {
     virtual void visualizeNegativeInformation(vizkit3d::PatchesGeode& geode) const = 0;
     virtual maps::grid::CellExtents getCellExtents() const = 0;
     virtual base::Transform3d getLocalFrame() const = 0;
-    MLSMapVisualization* visualization;
+    MLSMapVisualization& visualization;
 };
 
 template<enum MLSConfig::update_model Type>
@@ -80,7 +81,7 @@ struct DataHold : public MLSMapVisualization::Data
 private:
     MLSMap<Type> mls;
 public:
-    DataHold(const MLSMap<Type> mls_) : mls(mls_)
+    DataHold(const MLSMap<Type> mls_, MLSMapVisualization& vis) : Data(vis), mls(mls_)
     {
     }
 
@@ -157,7 +158,7 @@ void visualize(vizkit3d::SurfaceGeode& geode) const
                     if (list.size()){
                         for (typename Cell::const_iterator it = list.begin()+levelOffset; it != list.end(); it++)
                         {
-                            visualization->visualize(geode, *it);
+                            visualization.visualize(geode, *it);
                         } // for(SPList ...)
                     }
                 } // for(y ...)
@@ -340,23 +341,20 @@ void MLSMapVisualization::updateMainNode ( osg::Node* node )
 
 void MLSMapVisualization::updateDataIntern(::maps::grid::MLSMapKalman const& value)
 {
-    p.reset(new DataHold<MLSConfig::KALMAN>( value ));
+    p.reset(new DataHold<MLSConfig::KALMAN>( value, *this ));
 }
 void MLSMapVisualization::updateDataIntern(::maps::grid::MLSMap<::maps::grid::MLSConfig::SLOPE> const& value)
 {
-    p.reset(new DataHold<MLSConfig::SLOPE>( value ));
-    p->visualization = this;
+    p.reset(new DataHold<MLSConfig::SLOPE>( value, *this ));
 }
 void MLSMapVisualization::updateDataIntern(::maps::grid::MLSMap<::maps::grid::MLSConfig::PRECALCULATED> const& value)
 {
-    p.reset(new DataHold<MLSConfig::PRECALCULATED>( value ));
-    p->visualization = this;
+    p.reset(new DataHold<MLSConfig::PRECALCULATED>( value, *this ));
 }
 
 void MLSMapVisualization::updateDataIntern(::maps::grid::MLSMap<::maps::grid::MLSConfig::BASE> const& value)
 {
-    p.reset(new DataHold<MLSConfig::BASE>( value ));
-    p->visualization = this;
+    p.reset(new DataHold<MLSConfig::BASE>( value, *this ));
 }
 
 bool MLSMapVisualization::isUncertaintyShown() const

--- a/viz/MLSMapVisualization.cpp
+++ b/viz/MLSMapVisualization.cpp
@@ -596,7 +596,7 @@ void MLSMapVisualization::visualize(vizkit3d::PatchesGeode& geode, const Surface
     Eigen::Vector3f normal = p.getNormal();
     if(normal.z() < 0)
         normal *= -1.0;
-    if(p.getNumerOfMeasurements() >= minMeasurements)
+    if(p.getNumberOfMeasurements() >= minMeasurements)
     {
         if(normal.allFinite())
         {

--- a/viz/MLSMapVisualization.cpp
+++ b/viz/MLSMapVisualization.cpp
@@ -589,6 +589,9 @@ void MLSMapVisualization::setMinMeasurements(int measurements)
 
 void MLSMapVisualization::visualize(vizkit3d::PatchesGeode& geode, const SurfacePatch<MLSConfig::SLOPE>& p)
 {
+    if(p.getNumberOfMeasurements() < minMeasurements)
+    	return;
+
     float minZ, maxZ;
     p.getRange(minZ, maxZ);
     minZ -= 5e-4f;
@@ -596,17 +599,15 @@ void MLSMapVisualization::visualize(vizkit3d::PatchesGeode& geode, const Surface
     Eigen::Vector3f normal = p.getNormal();
     if(normal.z() < 0)
         normal *= -1.0;
-    if(p.getNumberOfMeasurements() >= minMeasurements)
+
+    if(normal.allFinite())
     {
-        if(normal.allFinite())
-        {
-            geode.drawPlane(Eigen::Hyperplane<float, 3>(normal, p.getCenter()), minZ, maxZ);
-        }
-        else
-        {
-            float height = (maxZ - minZ) + 1e-3f;
-            geode.drawBox(maxZ, height, osg::Vec3(0.f,0.f,1.f));
-        }
+        geode.drawPlane(Eigen::Hyperplane<float, 3>(normal, p.getCenter()), minZ, maxZ);
+    }
+    else
+    {
+        float height = (maxZ - minZ) + 1e-3f;
+        geode.drawBox(maxZ, height, osg::Vec3(0.f,0.f,1.f));
     }
 }
 

--- a/viz/MLSMapVisualization.hpp
+++ b/viz/MLSMapVisualization.hpp
@@ -39,6 +39,8 @@
 
 namespace vizkit3d
 {
+    class PatchesGeode;
+
     class MLSMapVisualization
         : public vizkit3d::MapVisualization< ::maps::grid::MLSMapKalman >
         , public vizkit3d::VizPluginAddType< ::maps::grid::MLSMap<::maps::grid::MLSConfig::SLOPE> >
@@ -63,10 +65,16 @@ namespace vizkit3d
         Q_PROPERTY(QColor vertical_cell_color READ getVerticalCellColor WRITE setVerticalCellColor)
         Q_PROPERTY(QColor negative_cell_color READ getNegativeCellColor WRITE setNegativeCellColor)
         Q_PROPERTY(QColor uncertainty_color READ getUncertaintyColor WRITE setUncertaintyColor)
+        Q_PROPERTY(int min_measurements READ getMinMeasurements WRITE setMinMeasurements)
 
         public:
             MLSMapVisualization();
             ~MLSMapVisualization();
+
+            void visualize(vizkit3d::PatchesGeode& geode, const maps::grid::SurfacePatch<maps::grid::MLSConfig::SLOPE>& p);
+            void visualize(vizkit3d::PatchesGeode& geode, const maps::grid::SurfacePatch<maps::grid::MLSConfig::PRECALCULATED>& p);
+            void visualize(vizkit3d::PatchesGeode& geode, const maps::grid::SurfacePatch<maps::grid::MLSConfig::KALMAN>& p);
+            void visualize(vizkit3d::PatchesGeode& geode, const maps::grid::SurfacePatch<maps::grid::MLSConfig::BASE>& p);
 
             Q_INVOKABLE void updateMLSPrecalculated(maps::grid::MLSMapPrecalculated const &sample)
             {vizkit3d::Vizkit3DPlugin<::maps::grid::MLSMapKalman>::updateData(sample);}
@@ -101,7 +109,7 @@ namespace vizkit3d
             virtual void updateDataIntern(::maps::grid::MLSMap<::maps::grid::MLSConfig::SLOPE> const& mls);
             virtual void updateDataIntern(::maps::grid::MLSMap<::maps::grid::MLSConfig::PRECALCULATED> const& mls);
             virtual void updateDataIntern(::maps::grid::MLSMap<::maps::grid::MLSConfig::BASE> const& mls);
-            
+
         private:
             struct Data;
             boost::scoped_ptr<Data> p;
@@ -155,6 +163,9 @@ namespace vizkit3d
             bool getConnectedSurfaceLOD() const;
             void setConnectedSurfaceLOD(bool enabled);
 
+            int getMinMeasurements() const;
+            void setMinMeasurements(int measurements);
+
         protected:
             osg::Vec4 horizontalCellColor;
             osg::Vec4 verticalCellColor;
@@ -169,6 +180,7 @@ namespace vizkit3d
             double cycleColorInterval;
             bool showPatchExtents;
             double uncertaintyScale;
+            int minMeasurements;
             bool connectedSurface;
             bool simplifySurface;
             bool connected_surface_lod;


### PR DESCRIPTION
- Added new parameter to show only patches that have a minimum number of measurements.
- Always draw patches face-up (normal vector pointing upwards)