### PR TITLE
check if config update model is same as the map surfacetype

### DIFF
--- a/src/grid/MLSMap.hpp
+++ b/src/grid/MLSMap.hpp
@@ -70,7 +70,8 @@ namespace maps { namespace grid
         : Base(num_cells, resolution)
         , config(config_)
         {
-            assert(config_.updateModel == SurfaceType);
+            LOG_FATAL_S << "Internal Error: Update model in MLS Config is not same as the MLSMap SurfaceType";
+            throw std::runtime_error("Internal Error: Update model in MLS Config is not same as the MLSMap SurfaceType"); 
         }
 
         MLSMap()

--- a/src/grid/MLSMap.hpp
+++ b/src/grid/MLSMap.hpp
@@ -70,7 +70,7 @@ namespace maps { namespace grid
         : Base(num_cells, resolution)
         , config(config_)
         {
-            // TODO assert that config is compatible to SurfaceType ...
+            assert(config_.updateModel == SurfaceType);
         }
 
         MLSMap()


### PR DESCRIPTION
Hello @planthaber 

it was not being checked whether the map updatemodel from the 'maps/grid/MLSConfig' is the same as the SurfaceType in MLSMap.

Either we add this assert from the PR or we can remove the updateModel from the  'maps/grid/MLSConfig' because it is currently unused

Best,
Haider