### PR TITLE
Slope normals

### DIFF
--- a/src/grid/GridMap.hpp
+++ b/src/grid/GridMap.hpp
@@ -52,10 +52,10 @@ namespace maps { namespace grid
     {
 
     protected:
-        /** 
+        /**
          * @brief Resolution of the cell in local x-axis and y-axis
          * @details
-         * Size of the cell in local x- und y-axis in some distance/length unit 
+         * Size of the cell in local x- und y-axis in some distance/length unit
          * (e.g. meter or inch)
          * The unit used in the resolution should be the same as the unit used for
          * the translation part of the local frame. (s. LocalMapData::offset)
@@ -67,7 +67,7 @@ namespace maps { namespace grid
         typedef boost::shared_ptr<GridMap<CellT, GridT> > Ptr;
         typedef const boost::shared_ptr<GridMap<CellT, GridT> > ConstPtr;
 
-        GridMap() 
+        GridMap()
             : LocalMap(maps::LocalMapType::GRID_MAP),
               GridT(),
               resolution(0,0)
@@ -75,7 +75,7 @@ namespace maps { namespace grid
         }
 
         GridMap(const GridMap& other)
-            : LocalMap(other), 
+            : LocalMap(other),
               GridT(other),
               resolution(other.resolution)
         {
@@ -147,7 +147,7 @@ namespace maps { namespace grid
             return getNumCells().prod();
         }
 
-        const Vector2d& getResolution() const 
+        const Vector2d& getResolution() const
         {
             return resolution;
         }
@@ -156,11 +156,11 @@ namespace maps { namespace grid
         {
             if(newRes.isApprox(resolution, 0.00001))
                 return;
-            
+
             resolution = newRes;
             this->clear();
         }
-        
+
         Vector2d getSize() const
         {
             return resolution.array() * getNumCells().template cast<double>().array();
@@ -174,10 +174,10 @@ namespace maps { namespace grid
         }
 
         /** @brief get a position of an index from the Grid
-         * 
+         *
          *  By default this function checks, if the index is within the grid,
          *  and returns false if the index is out of the grid.
-         * 
+         *
          *  If the index is inside the grid, or checkIndex is set to false,
          *  this function will convert the given position into frame coordinates.
          * */
@@ -322,7 +322,7 @@ namespace maps { namespace grid
             return toGrid(pos_in_map, idx);
         }
 
-        bool toGrid(const Vector3d& pos, Index& idx, bool checkIndex = true) const 
+        bool toGrid(const Vector3d& pos, Index& idx, bool checkIndex = true) const
         {
             // Get the 2D position without the offset (in grid_frame)
             // pos_grid = Tgrid_local pos_local
@@ -330,16 +330,16 @@ namespace maps { namespace grid
 
             // Get the index for the pos_grid
             Eigen::Vector2d idx_double = pos_grid.array() / resolution.array();
-            
+
             Index idx_temp(std::floor(idx_double.x()), std::floor(idx_double.y()));
 
             if(checkIndex && !inGrid(idx_temp))
             {
                 return false;
             }
-            
+
             idx = idx_temp;
-            
+
             return true;
         }
         /**
@@ -357,9 +357,10 @@ namespace maps { namespace grid
 
         /** @brief optimized variant of toGrid(const Vector3d& pos, Index& idx, Vector3d &pos_in_cell)
          */
-        bool toGridOptimized(const Vector3d& pos, Index& idx, Vector3d& pos_in_cell, const base::Transform3d& trafo)
+        bool toGridOptimized(const Vector3d& pos, Index& idx, Vector3d& pos_in_cell, const base::Transform3d& trafo, Vector3d& viewPoint_in_cell)
         {
             Vector3d pos_in_grid = trafo * pos;
+            Vector3d viewPoint_in_grid = trafo.translation();
 
             Index idx_temp(std::round(pos_in_grid.x()), std::round(pos_in_grid.y()));
 
@@ -367,6 +368,7 @@ namespace maps { namespace grid
             {
                 idx = idx_temp;
                 pos_in_cell << (pos_in_grid.head<2>() - idx.cast<double>()).cwiseProduct(resolution), pos_in_grid.z();
+                viewPoint_in_cell << (viewPoint_in_grid.head<2>() - idx.cast<double>()).cwiseProduct(resolution), viewPoint_in_grid.z();
                 return true;
             }
             return false;
@@ -552,7 +554,7 @@ namespace maps { namespace grid
 
             // ---------- Upper border
             // y: from 0 until first value is found
-            // x : from x_min to getNumCells().x() 
+            // x : from x_min to getNumCells().x()
             has_value = false;
             int y_min = -1;
             while (has_value == false)
@@ -562,10 +564,10 @@ namespace maps { namespace grid
                 if (addCellForY(cell_extents, y_min, x_min, num_cells.x() - 1) == true)
                 {
                     has_value = true;
-                }                
+                }
             }
 
-            // ------------ Right border 
+            // ------------ Right border
             // x: from getNumCells().x() - 1 until first value is found
             // y: from y_min until getNumCells().y()
             has_value = false;
@@ -592,8 +594,8 @@ namespace maps { namespace grid
                 if (addCellForY(cell_extents, y_max, x_min, x_max) == true)
                 {
                     has_value = true;
-                }               
-            }          
+                }
+            }
 
             return cell_extents;
         }
@@ -619,9 +621,9 @@ namespace maps { namespace grid
             {
                 if (isDefault(at(x, y)) == false)
                 {
-                    cell_extents.extend(Vector2ui(x, y));                  
+                    cell_extents.extend(Vector2ui(x, y));
                     return true;
-                }                      
+                }
                 y++;
             }
             return false;
@@ -636,7 +638,7 @@ namespace maps { namespace grid
                 {
                     cell_extents.extend(Vector2ui(x, y));
                     return true;
-                }                      
+                }
                 x++;
             }
             return false;

--- a/src/grid/MLSMap.hpp
+++ b/src/grid/MLSMap.hpp
@@ -61,7 +61,7 @@ namespace maps { namespace grid
         public:
             typedef SurfacePatch<SurfaceType> Patch;
             typedef MultiLevelGridMap<Patch> Base;
-            typedef LevelList<Patch> CellType; 
+            typedef LevelList<Patch> CellType;
 
         MLSMap(
                 const Vector2ui &num_cells,
@@ -349,11 +349,12 @@ namespace maps { namespace grid
          */
         void mergePoint(const Eigen::Vector3d& point, const base::Transform3d& pc2gridframe, double measurement_variance = 0.01)
         {
-            Eigen::Vector3d pos_diff;
+            Eigen::Vector3d point_in_cell;
+            Eigen::Vector3d viewPoint_in_cell;
             Index idx;
-            if(Base::toGridOptimized(point, idx, pos_diff, pc2gridframe))
+            if(Base::toGridOptimized(point, idx, point_in_cell, pc2gridframe, viewPoint_in_cell))
             {
-                mergePatch(idx, Patch(pos_diff.cast<float>(), measurement_variance));
+                mergePatch(idx, Patch(point_in_cell.cast<float>(), measurement_variance, viewPoint_in_cell.cast<float>()));
             }
             else
                 throw std::runtime_error((boost::format("Point %1% is outside of the grid! Can't add to grid.") % point.transpose()).str());

--- a/viz/MLSMapVisualization.cpp
+++ b/viz/MLSMapVisualization.cpp
@@ -597,8 +597,8 @@ void MLSMapVisualization::visualize(vizkit3d::PatchesGeode& geode, const Surface
     minZ -= 5e-4f;
     maxZ += 5e-4f;
     Eigen::Vector3f normal = p.getNormal();
-    if(normal.z() < 0)
-        normal *= -1.0;
+    //if(normal.z() < 0)
+    //    normal *= -1.0;
 
 
     if(normal.allFinite())

--- a/viz/MLSMapVisualization.cpp
+++ b/viz/MLSMapVisualization.cpp
@@ -86,7 +86,7 @@ public:
     }
 
     Eigen::Vector2d getResolution() const { return mls.getResolution(); }
-    
+
 
 void visualize(vizkit3d::SurfaceGeode& geode) const
     {
@@ -143,7 +143,7 @@ void visualize(vizkit3d::SurfaceGeode& geode) const
         Vector2ui num_cell = mls.getNumCells();
 
             //const GridMap<SPListST> &mls = *this;
-            
+
             for (size_t x = 0; x < num_cell.x(); x++)
             {
                 for (size_t y = 0; y < num_cell.y(); y++)
@@ -162,7 +162,7 @@ void visualize(vizkit3d::SurfaceGeode& geode) const
                         } // for(SPList ...)
                     }
                 } // for(y ...)
-            } // for(x ...)        
+            } // for(x ...)
 
 
 
@@ -222,9 +222,9 @@ MLSMapVisualization::MLSMapVisualization()
     : MapVisualization< maps::grid::MLSMapKalman >(),
     p(0),
     horizontalCellColor(osg::Vec4(0.1,0.5,0.9,1.0)),
-    verticalCellColor(osg::Vec4(0.8,0.9,0.5,1.0)), 
-    negativeCellColor(osg::Vec4(0.1,0.5,0.9,0.2)), 
-    uncertaintyColor(osg::Vec4(0.5,0.1,0.1,0.3)), 
+    verticalCellColor(osg::Vec4(0.8,0.9,0.5,1.0)),
+    negativeCellColor(osg::Vec4(0.1,0.5,0.9,0.2)),
+    uncertaintyColor(osg::Vec4(0.5,0.1,0.1,0.3)),
     showUncertainty(false),
     showNegative(false),
     estimateNormals(false),
@@ -510,7 +510,7 @@ void MLSMapVisualization::setUncertaintyColor(QColor color)
     setDirty();
 }
 
-void MLSMapVisualization::setShowPatchExtents( bool value ) 
+void MLSMapVisualization::setShowPatchExtents( bool value )
 {
     showPatchExtents = value;
     if(value && (areNormalsShown() || isUncertaintyShown()))
@@ -600,6 +600,7 @@ void MLSMapVisualization::visualize(vizkit3d::PatchesGeode& geode, const Surface
     if(normal.z() < 0)
         normal *= -1.0;
 
+
     if(normal.allFinite())
     {
         geode.drawPlane(Eigen::Hyperplane<float, 3>(normal, p.getCenter()), minZ, maxZ);
@@ -609,6 +610,7 @@ void MLSMapVisualization::visualize(vizkit3d::PatchesGeode& geode, const Surface
         float height = (maxZ - minZ) + 1e-3f;
         geode.drawBox(maxZ, height, osg::Vec3(0.f,0.f,1.f));
     }
+
 }
 
 void MLSMapVisualization::visualize(vizkit3d::PatchesGeode& geode, const SurfacePatch<MLSConfig::PRECALCULATED>& p)

--- a/viz/MLSMapVisualization.cpp
+++ b/viz/MLSMapVisualization.cpp
@@ -142,8 +142,6 @@ void visualize(vizkit3d::SurfaceGeode& geode) const
     {
         Vector2ui num_cell = mls.getNumCells();
 
-            //const GridMap<SPListST> &mls = *this;
-
             for (size_t x = 0; x < num_cell.x(); x++)
             {
                 for (size_t y = 0; y < num_cell.y(); y++)

--- a/viz/MLSMapVisualization.cpp
+++ b/viz/MLSMapVisualization.cpp
@@ -597,9 +597,6 @@ void MLSMapVisualization::visualize(vizkit3d::PatchesGeode& geode, const Surface
     minZ -= 5e-4f;
     maxZ += 5e-4f;
     Eigen::Vector3f normal = p.getNormal();
-    //if(normal.z() < 0)
-    //    normal *= -1.0;
-
 
     if(normal.allFinite())
     {


### PR DESCRIPTION
@skasperski Hello Sebastian!

Could you please check the commits?
Now the normals in the slope mls will have the orientation according to the view point of pointcloud. 
Also the drawing of the surface patches are fixed. so backculling can be used.
The fix for normals in vizkit is removed.

The slope surface patch has now new member `meanViewPoint`. We added there a condition to check the serialization version of the mls map. It needs to be testes if the old maps can be loaded correctly. 

@chhtz Christoph and Anna