### PR TITLE
Fix numerous warnings

### DIFF
--- a/src/geometric/Point.hpp
+++ b/src/geometric/Point.hpp
@@ -65,7 +65,7 @@ namespace boost { namespace serialization
     template<class Archive, typename T, int D>
     void serialize(Archive & ar, ::maps::geometric::Point<T, D> & t, const unsigned int version)
     {
-        for(size_t i=0; i<t.size(); i++)
+        for(Eigen::Index i=0; i<t.size(); i++)
             ar & BOOST_SERIALIZATION_NVP(t[i]);
     }
 }}

--- a/src/grid/LevelList.hpp
+++ b/src/grid/LevelList.hpp
@@ -37,7 +37,7 @@ namespace maps { namespace grid
 struct MLSConfig;
 
 template <class _Tp>
-struct myCmp : public std::binary_function<_Tp, _Tp, bool>
+struct myCmp
 {
     bool
     operator()(const _Tp& __x, const _Tp& __y) const

--- a/src/grid/SurfacePatches.hpp
+++ b/src/grid/SurfacePatches.hpp
@@ -294,7 +294,7 @@ protected:
         ar & BOOST_SERIALIZATION_NVP(n);
         if(version == 0)
         {
-            TYPE type;
+            TYPE type{};
             ar & BOOST_SERIALIZATION_NVP(type);
         }
     }    

--- a/src/grid/TraversabilityMap3d.hpp
+++ b/src/grid/TraversabilityMap3d.hpp
@@ -379,7 +379,7 @@ namespace maps { namespace grid
             }
             saveSizeValue(ar, size);
 
-            //save all connections together with the coresponding pointer
+            //save all connections together with the corresponding pointer
             for(const maps::grid::LevelList<T *> &ll : *this )
             {
                 for(T *node: ll)

--- a/src/grid/VectorGrid.hpp
+++ b/src/grid/VectorGrid.hpp
@@ -205,20 +205,20 @@ namespace maps { namespace grid
 
         /**
          * Returns iterators to the first and one element after the last element
-         * containing values unequal to the defaut value.
+         * containing values unequal to the default value.
          */
         std::pair<const_iterator, const_iterator> getRange() const
         {
-            const_iterator start_range = std::find_if(cells.begin(), cells.end(), 
-                std::bind1st(std::not_equal_to<CellT>(), default_value));
+            auto const find_non_default = [&](const CellT& x){return x!=default_value;};
+
+            const_iterator start_range = std::find_if(cells.begin(), cells.end(), find_non_default);
 
             // cells are all default
             if(start_range == cells.end())
                 return std::make_pair(start_range, cells.end());
 
             typename std::vector<CellT>::const_reverse_iterator r_end_range = 
-                std::find_if(cells.crbegin(), cells.crend(),
-                    std::bind1st(std::not_equal_to<CellT>(), default_value));
+                std::find_if(cells.crbegin(), cells.crend(), find_non_default);
 
             const_iterator end_range(r_end_range.base());
             return std::pair<const_iterator, const_iterator>(start_range, end_range);
@@ -245,7 +245,7 @@ namespace maps { namespace grid
                 // identify the next block of occupied or non-occupied cells
                 nextBlock(block_start_cell, block_size, block_occupied, block_end_cell);
 
-                // save bock header
+                // save block header
                 ar << block_occupied;
                 saveSizeValue(ar, block_size);
 
@@ -327,12 +327,9 @@ namespace maps { namespace grid
             // check if the start cell is occupied
             block_occupied = *start_cell != default_value;
             // find next either occupied or non-occupied cell
-            if (block_occupied)
-                end_cell = std::find_if_not(start_cell+1, cells.end(),
-                                                     std::bind1st(std::not_equal_to<CellT>(), default_value));
-            else
-                end_cell = std::find_if_not(start_cell+1, cells.end(),
-                                                     std::bind1st(std::equal_to<CellT>(), default_value));
+            end_cell = std::find_if(start_cell+1, cells.end(),
+                        [&](const CellT& x) { return (x==default_value) == block_occupied;}
+            );
             // compute block size
             block_size = std::distance(start_cell, end_cell);
         }

--- a/test/grid/test_LayeredGridMap.cpp
+++ b/test/grid/test_LayeredGridMap.cpp
@@ -105,11 +105,12 @@ BOOST_AUTO_TEST_CASE(test_gridmap_has)
     BOOST_CHECK_EQUAL(grid_map->hasLayer("double_grid"), true);
 
     GridMap<double> &grid = grid_map->getLayer<double>("double_grid");
+    BOOST_CHECK_EQUAL(grid.getId(),  maps::UNKNOWN_MAP_ID);
 
     // check if the existence of the grid after it was removed
     grid_map->removeLayer("double_grid"); 
     BOOST_CHECK_EQUAL(grid_map->hasLayer("double_grid"), false);
-    BOOST_CHECK_EQUAL(grid.getId(),  maps::UNKNOWN_MAP_ID);
+    BOOST_CHECK_THROW(grid_map->getLayer<double>("double_grid"), std::exception);
 
     delete grid_map;
 }

--- a/test/grid/test_MLGrid.cpp
+++ b/test/grid/test_MLGrid.cpp
@@ -76,13 +76,13 @@ class PatchBase
 class Patch : public PatchBase
 {
 public:
-    Patch() : PatchBase(0,0)
+    Patch() : PatchBase(0,0), someValue(0)
     {
     };
 
     virtual ~Patch(){};
 
-    Patch(double m, double ma) : PatchBase(m, ma)
+    Patch(double m, double ma, double someValue_ = 0.0) : PatchBase(m, ma), someValue(someValue_)
     {
     };
 


### PR DESCRIPTION
* std::binary_function is deprecated and not needed anymore (with C++11 or later)
* std::bind1st is deprecated -- replaced by lambda
* Also signed/unsigned comparison and unintialized values Fixed test_LayeredGrid (no idea how this could have passed before)