### PR TITLE
Enable viz-unit tests also for Qt5

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,6 @@ add_subdirectory(tools)
 
 # TEST VISUALIZATION
 #
-if( vizkit3d_FOUND AND OSGVIZ_PRIMITIVES_FOUND)
+if( (vizkit3d_FOUND OR vizkit3d-qt5_FOUND) AND OSGVIZ_PRIMITIVES_FOUND)
     add_subdirectory(viz)
 endif()

--- a/test/viz/CMakeLists.txt
+++ b/test/viz/CMakeLists.txt
@@ -1,67 +1,90 @@
 include_directories(BEFORE ${PROJECT_SOURCE_DIR}/viz)
-rock_find_qt4(QtCore QtGui)
+rock_find_qt4(QtCore QtGui OPTIONAL)
+rock_find_qt5(Qt5Core Qt5Gui OPTIONAL)
 
 add_compile_options(-fPIC)
 
-rock_executable(heightmap_to_mls
+if (ROCK_QT_VERSION_4)
+  rock_executable(heightmap_to_mls
     SOURCES
     mlsFromImageHeightmap.cpp
-    HEADERS    
-   DEPS_PKGCONFIG QtCore QtGui vizkit3d vizkit3d-viz
-   DEPS maps-viz maps)
+    DEPS_PKGCONFIG QtCore QtGui vizkit3d-viz
+    DEPS maps-viz maps)
 
-rock_testsuite(test_viz_elevationmap 
+  macro(mapviz_test_qt4 name sourcefile)
+    rock_testsuite(${name}
+        ${sourcefile}
+        DEPS_PKGCONFIG vizkit3d-viz
+        DEPS maps-viz)
+  endmacro()
+else()
+  macro(mapviz_test_qt4)
+  endmacro()
+endif()
+
+if (ROCK_QT_VERSION_5)
+  rock_executable(heightmap_to_mls-qt5
+    SOURCES
+    mlsFromImageHeightmap.cpp
+    DEPS_PKGCONFIG Qt5Core Qt5Gui vizkit3d-viz-qt5
+    DEPS maps-viz-qt5 maps)
+
+  macro(mapviz_test_qt5 name sourcefile)
+    rock_testsuite(${name}-qt5
+        ${sourcefile}
+        DEPS_PKGCONFIG vizkit3d-viz-qt5
+        DEPS maps-viz-qt5)
+  endmacro()
+else()
+  macro(mapviz_test_qt5)
+  endmacro()
+endif()
+
+macro(mapviz_test name source)
+  mapviz_test_qt4(${name} ${source})
+  mapviz_test_qt5(${name} ${source})
+endmacro()
+
+mapviz_test(test_viz_elevationmap 
     test_viz_ElevationMap.cpp
-    DEPS maps-viz
-    DEPS_PKGCONFIG vizkit3d  vizkit3d-viz)
+)
 
-rock_testsuite(test_viz_mlsmap
+mapviz_test(test_viz_mlsmap
     test_viz_MLSMap.cpp
-    DEPS maps-viz
-    DEPS_PKGCONFIG vizkit3d  vizkit3d-viz)
+)
 
-rock_testsuite(test_viz_mlslidar 
+mapviz_test(test_viz_mlslidar 
     test_viz_MLSLIDAR.cpp
-    DEPS maps-viz
-    DEPS_PKGCONFIG vizkit3d  vizkit3d-viz)
+)
 
-rock_testsuite(test_viz_countourmap
+mapviz_test(test_viz_countourmap
     test_viz_ContourMap.cpp
-    DEPS maps-viz
-    DEPS_PKGCONFIG vizkit3d  vizkit3d-viz)
+)
 
-rock_testsuite(test_viz_gridmap
+mapviz_test(test_viz_gridmap
     test_viz_GridMap.cpp
-    DEPS maps-viz
-    DEPS_PKGCONFIG vizkit3d  vizkit3d-viz)
+)
 
-rock_executable(deserialize_test 
+mapviz_test(deserialize_test 
     DeserializeVizTest.cpp
-    DEPS_CMAKE Boost
-    DEPS maps-viz
-    DEPS_PKGCONFIG vizkit3d  vizkit3d-viz)
+)
 
-rock_testsuite(test_viz_tsdf_map
+mapviz_test(test_viz_tsdf_map
     test_viz_TSDFMap.cpp
-    DEPS maps-viz
-    DEPS_PKGCONFIG vizkit3d vizkit3d-viz)
+)
 
-rock_testsuite(test_viz_occupancylidar
+mapviz_test(test_viz_occupancylidar
     test_viz_OccupancyLidar.cpp
-    DEPS maps-viz
-    DEPS_PKGCONFIG vizkit3d  vizkit3d-viz)
+)
 
-rock_testsuite(test_viz_coverage
+mapviz_test(test_viz_coverage
     test_viz_Coverage.cpp
-    DEPS maps-viz
-    DEPS_PKGCONFIG vizkit3d  vizkit3d-viz)
+)
 
-rock_testsuite(test_viz_traversabilitygrid
+mapviz_test(test_viz_traversabilitygrid
     test_viz_TraversabilityGrid.cpp
-    DEPS maps-viz
-    DEPS_PKGCONFIG vizkit3d vizkit3d-viz)
+)
 
-rock_testsuite(test_viz_traversability_map3d
+mapviz_test(test_viz_traversability_map3d
     test_viz_TraversabilityMap3d.cpp
-    DEPS maps-viz
-    DEPS_PKGCONFIG vizkit3d vizkit3d-viz)
+)

--- a/test/viz/CMakeLists.txt
+++ b/test/viz/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_directories(BEFORE ${PROJECT_SOURCE_DIR}/viz)
-rock_find_qt4(QtCore QtGui OPTIONAL)
-rock_find_qt5(Qt5Core Qt5Gui OPTIONAL)
+rock_find_qt4(OPTIONAL)
+rock_find_qt5(OPTIONAL)
 
 add_compile_options(-fPIC)
 
@@ -8,13 +8,11 @@ if (ROCK_QT_VERSION_4)
   rock_executable(heightmap_to_mls
     SOURCES
     mlsFromImageHeightmap.cpp
-    DEPS_PKGCONFIG QtCore QtGui vizkit3d-viz
     DEPS maps-viz maps)
 
   macro(mapviz_test_qt4 name sourcefile)
     rock_testsuite(${name}
         ${sourcefile}
-        DEPS_PKGCONFIG vizkit3d-viz
         DEPS maps-viz)
   endmacro()
 else()
@@ -26,13 +24,11 @@ if (ROCK_QT_VERSION_5)
   rock_executable(heightmap_to_mls-qt5
     SOURCES
     mlsFromImageHeightmap.cpp
-    DEPS_PKGCONFIG Qt5Core Qt5Gui vizkit3d-viz-qt5
     DEPS maps-viz-qt5 maps)
 
   macro(mapviz_test_qt5 name sourcefile)
     rock_testsuite(${name}-qt5
         ${sourcefile}
-        DEPS_PKGCONFIG vizkit3d-viz-qt5
         DEPS maps-viz-qt5)
   endmacro()
 else()


### PR DESCRIPTION
This just enables the qt-based unit tests.
Actually, tests are not really suitable for automatic unit tests.
All tests require looking at the output and manually closing the application.
Some actually require a command line parameter or stdin-input.
Probably they should be disabled by default, even if they are possible to be build.