### PR TITLE
Use target_compile_features instead of set(CMAKE_CXX_STANDARD 14)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,7 @@
 # CMakeLists.txt has to be located in the project folder and cmake has to be
 # executed from 'project/build' with 'cmake ../'.
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(maps VERSION 0.1)
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(Rock)
 
 if(COVERAGE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,3 +85,5 @@ rock_library(maps
         Boost::serialization
 )
 
+target_compile_features(maps PUBLIC cxx_std_14)
+


### PR DESCRIPTION
The latter spills into the maps.pc file, which potentially breaks building dependencies which require a higher standard Also increase cmake_minimum_required to silence a warning